### PR TITLE
fix pyver bug in hkust/v1/local/hkust_prepare_dict.sh

### DIFF
--- a/asr_egs/hkust/v1/local/hkust_prepare_dict.sh
+++ b/asr_egs/hkust/v1/local/hkust_prepare_dict.sh
@@ -54,7 +54,7 @@ gawk 'NR==FNR{words[$1]; next;} ($1 in words)' \
 wc -l $dict_dir/vocab-en-oov.txt
 wc -l $dict_dir/lexicon-en-iv.txt
 
-pyver=`python --version 2>&1 | sed -e 's:.*\([2-3]\.[0-9]\+\).*:\1:g'`
+pyver=`python --version 2>&1 | sed -e 's:^[A-Za-z ]*\([2-3]\.[0-9]\+\).*:\1:g'`
 export PYTHONPATH=$PYTHONPATH:`pwd`/tools/g2p/lib/python${pyver}/site-packages
 if [ ! -f tools/g2p/lib/python${pyver}/site-packages/g2p.py ]; then
   echo "--- Downloading Sequitur G2P ..."


### PR DESCRIPTION
I used _anaconda python_ and the python version is 2.7 to run the script in hkust and it always failed in installing G2P. The problem is the `$pyver` get the wrong python version. So I changed `sed` a little to make it work in this case.

![pyver](https://cloud.githubusercontent.com/assets/13360214/11092701/39790cde-88c0-11e5-8a7b-dfee1ba5b41b.png)
