### PR TITLE
fix mmseg installation bug in hkust/v1/local/hkust_data_prep.sh

### DIFF
--- a/asr_egs/hkust/v1/local/hkust_data_prep.sh
+++ b/asr_egs/hkust/v1/local/hkust_data_prep.sh
@@ -76,9 +76,9 @@ find $HKUST_TEXT_DIR -iname "*.txt" | grep -i "trans/dev" | xargs cat |\
 #transcripts normalization and segmentation 
 #(this needs external tools),
 #Download and configure segment tools  
-pyver=`python --version 2>&1 | sed -e 's:.*\([2-3]\.[0-9]\+\).*:\1:g'`
+pyver=`python --version 2>&1 | sed -e 's:^[A-Za-z ]*\([2-3]\.[0-9]\+\).*:\1:g'`
 export PYTHONPATH=$PYTHONPATH:`pwd`/tools/mmseg-1.3.0/lib/python${pyver}/site-packages
-if [ ! -d tools/mmseg-1.3.0/lib/python${pyver}/site-packages ]; then
+if [ ! -f tools/mmseg-1.3.0/lib/python${pyver}/site-packages/*/mmseg.py ]; then
   echo "--- Downloading mmseg-1.3.0 ..."
   echo "NOTE: it assumes that you have Python, Setuptools installed on your system!"
   wget -P tools http://pypi.python.org/packages/source/m/mmseg/mmseg-1.3.0.tar.gz 
@@ -89,7 +89,7 @@ if [ ! -d tools/mmseg-1.3.0/lib/python${pyver}/site-packages ]; then
   python setup.py build 
   python setup.py install --prefix=.
   cd ../..
-  if [ ! -d tools/mmseg-1.3.0/lib/python${pyver}/site-packages ]; then
+  if [ ! -f tools/mmseg-1.3.0/lib/python${pyver}/site-packages/*/mmseg.py ]; then
     echo "mmseg is not found - installation failed?"
     exit 1
   fi

--- a/asr_egs/hkust/v1/local/hkust_prepare_dict.sh
+++ b/asr_egs/hkust/v1/local/hkust_prepare_dict.sh
@@ -195,7 +195,7 @@ cat $dict_dir/lexicon-ch-oov.txt |\
   ' > $dict_dir/lexicon-ch-oov1.txt
 
 cat $dict_dir/lexicon-ch-oov1.txt $dict_dir/lexicon-ch-iv.txt |\
-  awk '{if (NF > 1) print $0;}' > $dict_dir/lexicon-ch.txt 
+  awk '{if (NF > 1) print $0;}' | grep [A-Z] > $dict_dir/lexicon-ch.txt 
 
 cat $dict_dir/lexicon-ch.txt | sed -e 's/U:/V/g' | sed -e 's/ R\([0-9]\)/ ER\1/g'|\
   utils/pinyin_map.pl conf/pinyin2cmu > $dict_dir/lexicon-ch-cmu.txt


### PR DESCRIPTION
The dir had been made by `mkdir -p lib/python${pyver}/site-packages`, so the `if` condition won't `exit`  even if the installation is failed.
