### PR TITLE
Support channel IDs other than '1'

### DIFF
--- a/src/decoderbin/lattice-to-ctm-conf.cc
+++ b/src/decoderbin/lattice-to-ctm-conf.cc
@@ -125,6 +125,13 @@ int main(int argc, char *argv[]) {
       clat_reader.FreeCurrent();
       fst::ScaleLattice(fst::LatticeScale(lm_scale, acoustic_scale), &clat);
 
+      std::size_t firstDash = key.find ("-");
+      int first = static_cast<int>(firstDash);
+      std::size_t nextDash = key.find ("-", first+1);
+      int next = static_cast<int>(nextDash);
+      int len = next - first;
+      std::string channel = key.substr(firstDash+1, len-1);
+
       MinimumBayesRisk *mbr = NULL;
 
       if (one_best_rspecifier == "") {
@@ -145,7 +152,7 @@ int main(int argc, char *argv[]) {
       KALDI_ASSERT(conf.size() == words.size() && words.size() == times.size());
       for (size_t i = 0; i < words.size(); i++) {
         KALDI_ASSERT(words[i] != 0); // Should not have epsilons.
-        ko.Stream() << key << " 1 " << (frame_shift * times[i].first) << ' '
+        ko.Stream() << key << " " << channel << " " << (frame_shift * times[i].first) << ' '
                     << (frame_shift * (times[i].second-times[i].first)) << ' '
                     << words[i] << ' ' << conf[i] << '\n';
       }


### PR DESCRIPTION
As described previously, this supports creation of CTM files with channel ids that match the channels in the source lattice, not just hard coded " 1 " 
