### PR TITLE
Add support for CUDA toolkits 7_*, 8_* together with new CUDA compute capabilities

### DIFF
--- a/src/gpucompute/Makefile
+++ b/src/gpucompute/Makefile
@@ -28,24 +28,44 @@ ifeq ($(CUDA), true)
 
   #Default compute capability architectures we compile with
   CUDA_ARCH=-gencode arch=compute_20,code=sm_20
+
   #Get the CUDA Toolkit version (remove decimal point char)
   CUDA_VERSION=$(shell $(CUDATKDIR)/bin/nvcc -V | grep release | sed -e 's|.*release ||' -e 's|,.*||' -e 's|\.||')
+  
   #For toolkit 4.2 or newer, add the compute capability 3.0 
   CUDA_VER_GT_4_2 := $(shell [ $(CUDA_VERSION) -ge 42 ] && echo true)
   ifeq ($(CUDA_VER_GT_4_2), true)
     CUDA_ARCH += -gencode arch=compute_30,code=sm_30
   endif
+  
   #For toolkit 5.0 or newer, add the compute capability 3.5 
   CUDA_VER_GT_5_0 := $(shell [ $(CUDA_VERSION) -ge 50 ] && echo true)
   ifeq ($(CUDA_VER_GT_5_0), true)
     CUDA_ARCH += -gencode arch=compute_35,code=sm_35
   endif
+  
   #For toolkit 6.0 or newer, add the compute capability 5.0
   CUDA_VER_GT_6_0 := $(shell [ $(CUDA_VERSION) -ge 60 ] && echo true)
   ifeq ($(CUDA_VER_GT_6_0), true)
     CUDA_ARCH += -gencode arch=compute_50,code=sm_50
   endif
-  #For toolkit older than 6.5, add the compute capability 1.0
+  
+  #For toolkit 7.0 or newer, add the compute capability 5.3
+  CUDA_VER_GT_7_0 := $(shell [ $(CUDA_VERSION) -ge 70 ] && echo true) 
+  ifeq ($(CUDA_VER_GT_7_0), true)
+    CUDA_ARCH += -gencode arch=compute_53,code=sm_53
+  endif
+
+  #For toolkit 8.0 or newer, add the compute capability 6.0, 6.1 and 6.2
+  CUDA_VER_GT_8_0 := $(shell [ $(CUDA_VERSION) -ge 80 ] && echo true)
+  ifeq ($(CUDA_VER_GT_8_0), true)
+    CUDA_ARCH += -gencode arch=compute_60,code=sm_60 \
+		 -gencode arch=compute_61,code=sm_61 \
+		 -gencode arch=compute_62,code=sm_62
+  endif
+
+
+  #For toolkit older than 6.5, add the compute capability 1.0 and 1.3
   CUDA_VER_GT_6_5 := $(shell [ $(CUDA_VERSION) -ge 65 ] && echo true)
   ifneq ($(CUDA_VER_GT_6_5), true)
     CUDA_ARCH += -gencode arch=compute_13,code=sm_13 \


### PR DESCRIPTION
Hello!

I had troubles running tedlium example script on my GTX 1070. I am using CUDA toolkit 8.0, which is the only supported CUDA toolkit for 1070.
After some research, I found out that eesen was compiled with old cuda compute capabilities (namely, **arch** and **code** parameters in CUDA_ARCH) which are presumably not supported on my 1070. I looked the way how these parameters are changed in [Kaldi](https://github.com/kaldi-asr/kaldi/blob/master/src/configure#L447) in order to support newer CUDA toolkits and tried to reproduce that way in Eesen. After my modifications, tedlium example started working properly.

So I decided that it will be a good idea to merge these changes upstream. 
