### PR TITLE
Added a frames-per-sec option to train-ctc-parallel

### DIFF
--- a/src/net/ctc-loss.cc
+++ b/src/net/ctc-loss.cc
@@ -84,7 +84,7 @@ void Ctc::Eval(const CuMatrixBase<BaseFloat> &net_out, const std::vector<int32> 
   // progressive reporting
   {
     if (sequences_progress_ >= report_step_) {
-      KALDI_VLOG(1) << "After " << sequences_num_ << " sequences (" << frames_/(100.0 * 3600) << "Hr): "
+      KALDI_VLOG(1) << "After " << sequences_num_ << " sequences (" << frames_/(frames_per_sec_ * 3600) << "Hr): "
                     << "Obj(log[Pzx]) = " << obj_progress_/sequences_progress_
                     << "   TokenAcc = " << 100.0*(1.0 - error_num_progress_/ref_num_progress_) << "%";
       // reset

--- a/src/net/ctc-loss.h
+++ b/src/net/ctc-loss.h
@@ -30,7 +30,7 @@ class Ctc {
  public:
   Ctc() : frames_(0), sequences_num_(0), ref_num_(0), error_num_(0), 
           frames_progress_(0), ref_num_progress_(0), error_num_progress_(0),
-          sequences_progress_(0), obj_progress_(0.0), report_step_(100) { }
+          sequences_progress_(0), obj_progress_(0.0), report_step_(100), frames_per_sec_(100.0) { }
   ~Ctc() { }
 
   /// CTC training over a single sequence from the labels. The errors are returned to [diff]
@@ -53,6 +53,9 @@ class Ctc {
   /// Set the step of reporting
   void SetReportStep(int32 report_step) { report_step_ = report_step;  }
 
+  /// Set frames per second
+  void SetFramesPerSec(float frames_per_sec) { frames_per_sec_ = frames_per_sec;  }
+
   /// Generate string with report
   std::string Report();
 
@@ -73,6 +76,7 @@ class Ctc {
   double obj_progress_;              // registry for the optimization objective
 
   int32 report_step_;                // report obj and accuracy every so many sequences/utterances
+  float frames_per_sec_;
 
   std::vector<int32> label_expand_;  // expanded version of the label sequence
   CuMatrix<BaseFloat> alpha_;        // alpha values

--- a/src/netbin/train-ctc-parallel.cc
+++ b/src/netbin/train-ctc-parallel.cc
@@ -75,7 +75,7 @@ int main(int argc, char *argv[]) {
     po.Register("utts-per-avg", &utts_per_avg, "Number of utterances to process per average (default is 500)");
 
     float frames_per_sec = 100.0;
-    po.Register("frames-per-sec", &frames_per_sec, "Number of utterances to process per average (default is 100)");
+    po.Register("frames-per-sec", &frames_per_sec, "Number of frames per second (default is 100)");
 
     po.Read(argc, argv);
 

--- a/src/netbin/train-ctc-parallel.cc
+++ b/src/netbin/train-ctc-parallel.cc
@@ -72,7 +72,10 @@ int main(int argc, char *argv[]) {
     po.Register("job-id", &job_id, "Subjob id in multi-GPU mode");
 
     int32 utts_per_avg = 500;
-    po.Register("utts-per-avg", &utts_per_avg, "Number of utterances to process per average (default is 250)");
+    po.Register("utts-per-avg", &utts_per_avg, "Number of utterances to process per average (default is 500)");
+
+    float frames_per_sec = 100.0;
+    po.Register("frames-per-sec", &frames_per_sec, "Number of utterances to process per average (default is 100)");
 
     po.Read(argc, argv);
 
@@ -118,6 +121,8 @@ int main(int argc, char *argv[]) {
     // Initialize CTC optimizer
     Ctc ctc;
     ctc.SetReportStep(report_step);
+    ctc.SetFramesPerSec(frames_per_sec);
+
     CuMatrix<BaseFloat> net_out, obj_diff;
 
     Timer time;


### PR DESCRIPTION
so that the corpus size estimates (in h) are correct in the log when a different frame rate than 100 is used in a setup.
