### PR TITLE
Improved optimization and implementation of adaptive learning rate algorithms (Adagrad, RMSProp)

### DIFF
--- a/src/gpucompute/cuda-kernels-wrappers.h
+++ b/src/gpucompute/cuda-kernels-wrappers.h
@@ -95,7 +95,15 @@ inline void cuda_mul_rows_vec(dim3 Gr, dim3 Bl, double *mat, const double *scale
 
 inline void cuda_add_vec_to_rows(dim3 Gr, dim3 Bl, float alpha, const float *row, float beta, float *dst, MatrixDim d) { cudaF_add_vec_to_rows(Gr,Bl,alpha,row,beta,dst,d); }
 inline void cuda_add_vec_to_rows(dim3 Gr, dim3 Bl, double alpha, const double *row, double beta, double *dst, MatrixDim d) { cudaD_add_vec_to_rows(Gr,Bl,alpha,row,beta,dst,d); }
- 
+
+inline void cuda_add_mat_mat_elements(dim3 Gr, dim3 Bl, float *data, const float *srcA_data,const float *srcB_data, MatrixDim dim,
+                                int srcA_stride, int srcB_stride, float alpha, float beta)
+                                {cudaF_add_mat_mat_elements(Gr,Bl,data,srcA_data,srcB_data,dim,srcA_stride,srcB_stride,alpha,beta);}
+
+inline void cuda_add_mat_mat_elements(dim3 Gr, dim3 Bl, double *data, const double *srcA_data,const double *srcB_data, MatrixDim dim,
+                                int srcA_stride, int srcB_stride, double alpha, double beta)
+                                {cudaD_add_mat_mat_elements(Gr,Bl,data,srcA_data,srcB_data,dim,srcA_stride,srcB_stride,alpha,beta);}
+
 /*
  * CuVector
  */
@@ -116,14 +124,15 @@ inline void cuda_vec_max(const double* v, double* value, int dim) { cudaD_vec_ma
 inline void cuda_add_diag_mat_mat(int Gr, int Bl, float alpha, float* v, int v_dim, const float* M, 
                                   int M_cols, int M_row_stride, int M_col_stride, const float *N, int N_row_stride, 
                                   int N_col_stride, int threads_per_element, float beta) {
-  cudaF_add_diag_mat_mat(Gr, Bl, alpha, v, v_dim, M, M_cols, M_row_stride, M_col_stride, N, N_row_stride,
-                         N_col_stride, threads_per_element, beta);
+    cudaF_add_diag_mat_mat(Gr, Bl, alpha, v, v_dim, M, M_cols, M_row_stride, M_col_stride, N, N_row_stride,
+                             N_col_stride, threads_per_element, beta);
 }
+
 inline void cuda_add_diag_mat_mat(int Gr, int Bl, double alpha, double* v, int v_dim, const double* M,
                                   int M_cols, int M_row_stride, int M_col_stride, const double *N, int N_row_stride,
                                   int N_col_stride, int threads_per_element, double beta) {
-  cudaD_add_diag_mat_mat(Gr, Bl, alpha, v, v_dim, M, M_cols, M_row_stride, M_col_stride, N, N_row_stride,
-                         N_col_stride, threads_per_element, beta);
+    cudaD_add_diag_mat_mat(Gr, Bl, alpha, v, v_dim, M, M_cols, M_row_stride, M_col_stride, N, N_row_stride,
+                             N_col_stride, threads_per_element, beta);
 }
 
 inline void cuda_add_vec_vec(int Gr, int Bl, float alpha, float* v, const float* x, const float* y, float beta, int dim) { cudaF_add_vec_vec(Gr,Bl,alpha,v,x,y,beta,dim); }
@@ -143,6 +152,12 @@ inline void cuda_vec_apply_exp(int Gr, int Bl, double* v, int dim) { cudaD_vec_a
 
 inline void cuda_vec_apply_log(int Gr, int Bl, float* v, float* flag, int dim) { cudaF_vec_apply_log(Gr,Bl,v,flag,dim); }
 inline void cuda_vec_apply_log(int Gr, int Bl, double* v, double* flag, int dim) { cudaD_vec_apply_log(Gr,Bl,v,flag,dim); }
+
+inline void cuda_sqrt_elements(dim3 Gr, dim3 Bl, float* data, float epsilon, MatrixDim d) { cudaF_sqrt_elements(Gr, Bl, data, epsilon, d); }
+inline void cuda_sqrt_elements(dim3 Gr, dim3 Bl, double* data, double epsilon, MatrixDim d) { cudaD_sqrt_elements(Gr, Bl, data, epsilon, d); }
+
+inline void cuda_invert_elements(dim3 Gr, dim3 Bl, float *data, MatrixDim d) { cudaF_invert_elements(Gr, Bl, data, d); }
+inline void cuda_invert_elements(dim3 Gr, dim3 Bl, double *data, MatrixDim d) { cudaD_invert_elements(Gr, Bl, data, d); }
 
 inline void cuda_add_row_sum_mat(dim3 Gr, dim3 Bl, const float *mat, float *vec_sum, MatrixDim d) { cudaF_add_row_sum_mat(Gr,Bl,mat,vec_sum,d); }
 inline void cuda_add_row_sum_mat(dim3 Gr, dim3 Bl, const double *mat, double *vec_sum, MatrixDim d) { cudaD_add_row_sum_mat(Gr,Bl,mat,vec_sum,d); }

--- a/src/gpucompute/cuda-kernels.h
+++ b/src/gpucompute/cuda-kernels.h
@@ -47,6 +47,15 @@ void cudaD_apply_exp(dim3 Gr, dim3 Bl, double* mat, MatrixDim d);
 void cudaF_apply_pow(dim3 Gr, dim3 Bl, float* mat, float power, MatrixDim d);
 void cudaD_apply_pow(dim3 Gr, dim3 Bl, double* mat, double power, MatrixDim d);
 
+void cudaF_apply_pow(dim3 Gr, dim3 Bl, float* mat, float epsilon, MatrixDim d);
+void cudaD_apply_pow(dim3 Gr, dim3 Bl, double* mat, double epsilon, MatrixDim d);
+
+void cudaF_sqrt_elements(dim3 Gr, dim3 Bl, float* mat, float epsilon, MatrixDim d);
+void cudaD_sqrt_elements(dim3 Gr, dim3 Bl, double* mat, double epsilon, MatrixDim d);
+
+void cudaF_invert_elements(dim3 Gr, dim3 Bl, float* mat, MatrixDim d);
+void cudaD_invert_elements(dim3 Gr, dim3 Bl, double* mat, MatrixDim d);
+
 void cudaF_apply_floor(dim3 Gr, dim3 Bl, float* mat, float floor_val, MatrixDim d);
 void cudaD_apply_floor(dim3 Gr, dim3 Bl, double* mat, double floor_val, MatrixDim d);
 
@@ -79,6 +88,11 @@ void cudaD_add_mat(dim3 Gr, dim3 Bl, double alpha, const double *src, double *ds
 
 void cudaF_add_vec_to_rows(dim3 Gr, dim3 Bl, float alpha, const float *row, float beta, float *dst, MatrixDim d);
 void cudaD_add_vec_to_rows(dim3 Gr, dim3 Bl, double alpha, const double *row, double beta, double *dst, MatrixDim d); 
+
+void cudaD_add_mat_mat_elements(dim3 Gr, dim3 Bl, double *data, const double *srcA_data, const double *srcB_data, MatrixDim dim, int srcA_stride, int srcB_stride, 
+                                double alpha, double beta); 
+void cudaF_add_mat_mat_elements(dim3 Gr, dim3 Bl, float *data, const float *srcA_data, const float *srcB_data, MatrixDim dim, int srcA_stride, int srcB_stride,
+                                float alpha, float beta);
 
 /*
  * CuVector

--- a/src/gpucompute/cuda-matrix.h
+++ b/src/gpucompute/cuda-matrix.h
@@ -106,6 +106,10 @@ class CuMatrixBase {
   void Scale(Real value);
   /// Apply log()
   void ApplyLog();
+  /// Apply pow()
+  void ApplyPow(Real power);
+  /// Apply sqrt(x+epsilon)
+  void ApplySqrt(Real epsilon);
   /// Sum of the matrix
   Real Sum() const;
   /// If the elements < floor_val, set them to floor_val
@@ -122,6 +126,8 @@ class CuMatrixBase {
   void SetRandUniform();
   /// Set to random values drawn from a uniform distribution [-range, range]
   void InitRandUniform(Real range);
+  // Invert elements
+  void InvertElements();
 
   /////////////////////////////////////////////////////
   /////  Activation
@@ -227,6 +233,11 @@ class CuMatrixBase {
                     const CuMatrixBase<Real>& B, MatrixTransposeType transB,
                     const Real beta);
 
+
+  void AddMatMatElements(Real alpha,
+                         const CuMatrixBase<Real> &A, 
+                         const CuMatrixBase<Real> &B, 
+                         Real beta);
 
   /////////////////////////////////////////////////////
   ///// SubMatrix and SubVector

--- a/src/gpucompute/cuda-vector.cc
+++ b/src/gpucompute/cuda-vector.cc
@@ -912,6 +912,52 @@ void CuVectorBase<Real>::AddColSumMat(Real alpha,
   }
 }
 
+template<typename Real>
+void CuVectorBase<Real>::ApplySqrt(Real epsilon) {
+#if HAVE_CUDA == 1
+  if (CuDevice::Instantiate().Enabled()) {
+    Timer tim;
+
+    dim3 dimBlock(CU1DBLOCK, 1);
+    dim3 dimGrid(n_blocks(dim_, CU1DBLOCK));
+    MatrixDim d = {1, dim_, dim_};
+
+    cuda_sqrt_elements(dimGrid, dimBlock, data_, epsilon, d);
+    CU_SAFE_CALL(cudaGetLastError());
+
+    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+  } else
+#endif
+  {
+    printf("SqrtElements not inplemented on CPU");
+    exit(-101);
+    //Vec().SqrtElements();
+  }
+}
+
+
+template<typename Real>
+void CuVectorBase<Real>::InvertElements() {
+#if HAVE_CUDA == 1
+  if (CuDevice::Instantiate().Enabled()) {
+    Timer tim;
+
+    dim3 dimBlock(CU1DBLOCK, 1);
+    dim3 dimGrid(n_blocks(dim_, CU1DBLOCK));
+    MatrixDim d = {1, dim_, dim_};
+
+    cuda_invert_elements(dimGrid, dimBlock, data_, d);
+    CU_SAFE_CALL(cudaGetLastError());
+
+    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+  } else
+#endif
+  {
+    printf("InvertElements not inplemented on CPU");
+    exit(-101);
+    //Vec().InvertElements();
+  }
+}
 
 template
 void CuVectorBase<float>::CopyToVec(VectorBase<float> *dst) const;

--- a/src/gpucompute/cuda-vector.h
+++ b/src/gpucompute/cuda-vector.h
@@ -98,12 +98,16 @@ class CuVectorBase {
   void ApplySoftMax();
   void ApplyExp();
   void ApplyLog();
+  void ApplySqrt(Real epsilon);
   MatrixIndexT ApplyFloor(Real floor_val);
   void ApplyCeiling(Real ceiling_val);
   void ApplyPow(Real power);
   Real Sum() const;
   void SetRandn();
   void InitRandUniform(Real range);
+  
+  // Invert elements
+  void InvertElements();
 
   CuSubVector<Real> Range(const MatrixIndexT o, const MatrixIndexT l) {
     return CuSubVector<Real>(*this, o, l);

--- a/src/net/affine-trans-layer.h
+++ b/src/net/affine-trans-layer.h
@@ -141,6 +141,12 @@ class AffineTransform : public TrainableLayer {
 
   void Update(const CuMatrixBase<BaseFloat> &input, const CuMatrixBase<BaseFloat> &diff, const UpdateRule
   rule=sgd_update) {
+
+    if (max_grad_ > 0) {
+      linearity_corr_.ApplyFloor(-max_grad_); linearity_corr.ApplyCeiling(max_grad_);
+      bias_corr_.ApplyFloor(-max_grad_); bias_corr_.ApplyCeiling(max_grad_);
+    }
+    
     // we use following hyperparameters from the option class
     BaseFloat lr = opts_.learn_rate;
     const BaseFloat mmt = opts_.momentum;

--- a/src/net/affine-trans-layer.h
+++ b/src/net/affine-trans-layer.h
@@ -85,6 +85,12 @@ class AffineTransform : public TrainableLayer {
       ExpectToken(is, binary, "<LearnRateCoef>");
       ReadBasicType(is, binary, &learn_rate_coef_);
     }
+
+    if ('<' == Peek(is, binary)) {
+      ExpectToken(is, binary, "<MaxGrad>");
+      ReadBasicType(is, binary, &max_grad_);
+    }
+
     // weights
     linearity_.Read(is, binary);
     bias_.Read(is, binary);
@@ -99,6 +105,8 @@ class AffineTransform : public TrainableLayer {
   void WriteData(std::ostream &os, bool binary) const {
     WriteToken(os, binary, "<LearnRateCoef>");
     WriteBasicType(os, binary, learn_rate_coef_);
+    WriteToken(os, binary, "<MaxGrad>");
+    WriteBasicType(os, binary, max_grad_);
     // weights
     linearity_.Write(os, binary);
     bias_.Write(os, binary);

--- a/src/net/affine-trans-layer.h
+++ b/src/net/affine-trans-layer.h
@@ -172,16 +172,22 @@ class AffineTransform : public TrainableLayer {
       lr *= learn_rate_coef_;
       linearity_.AddMat(-lr, linearity_corr_);
       bias_.AddVec(-lr, bias_corr_);
-    } else if (rule==adagrad_update) {
+    } else if (rule==adagrad_update || rule==rmsprop_update) {
 
       if (!adaBuffersInitialized) {
         InitAdaBuffers();
         adaBuffersInitialized=true;
       }
 
-      // update the accumolators
-      AdagradAccuUpdate(linearity_corr_accu, linearity_corr_, linearity_corr_accu_scale);
-      AdagradAccuUpdate(bias_corr_accu, bias_corr_, bias_corr_accu_scale);
+      // update the accumolatorsi
+      if (rule==adagrad_update)
+      {
+        AdagradAccuUpdate(linearity_corr_accu, linearity_corr_, linearity_corr_accu_scale);
+        AdagradAccuUpdate(bias_corr_accu, bias_corr_, bias_corr_accu_scale);
+      }else {
+        RMSPropAccuUpdate(linearity_corr_accu, linearity_corr_, linearity_corr_accu_scale);
+        RMSPropAccuUpdate(bias_corr_accu, bias_corr_, bias_corr_accu_scale);
+      }
       // calculate 1.0 / sqrt(accu + epsilon)
       AdagradScaleCompute(linearity_corr_accu_scale, linearity_corr_accu);
       AdagradScaleCompute(bias_corr_accu_scale, bias_corr_accu);

--- a/src/net/affine-trans-layer.h
+++ b/src/net/affine-trans-layer.h
@@ -65,10 +65,10 @@ class AffineTransform : public TrainableLayer {
     bias_.Resize(output_dim_, kUndefined); bias_.InitRandUniform(param_range);
     
     // initialize Ada vars
-    linearity_accu.Resize(output_dim_, input_dim_, kUndefined); linearity_accu.Set(0.0);
-    bias_accu.Resize(output_dim_, kUndefined); bias_accu.Set(0.0);
-    linearity_accu_scale.Resize(output_dim_, input_dim_, kUndefined); linearity_accu_scale.Set(0.0);
-    bias_accu_scale.Resize(output_dim_, kUndefined); bias_accu_scale.Set(0.0);
+    linearity_corr_accu.Resize(output_dim_, input_dim_, kUndefined); linearity_corr_accu.Set(0.0);
+    bias_corr_accu.Resize(output_dim_, kUndefined); bias_corr_accu.Set(0.0);
+    linearity_corr_accu_scale.Resize(output_dim_, input_dim_, kUndefined); linearity_corr_accu_scale.Set(0.0);
+    bias_corr_accu_scale.Resize(output_dim_, kUndefined); bias_corr_accu_scale.Set(0.0);
     //
     learn_rate_coef_ = learn_rate_coef;
   }
@@ -129,7 +129,8 @@ class AffineTransform : public TrainableLayer {
     in_diff->AddMatMat(1.0, out_diff, kNoTrans, linearity_, kNoTrans, 0.0);
   }
 
-  void Update(const CuMatrixBase<BaseFloat> &input, const CuMatrixBase<BaseFloat> &diff, const UpdateRule rule) {
+  void Update(const CuMatrixBase<BaseFloat> &input, const CuMatrixBase<BaseFloat> &diff, const UpdateRule
+  rule=sgd_update) {
     // we use following hyperparameters from the option class
     const BaseFloat lr = opts_.learn_rate * learn_rate_coef_;
     const BaseFloat mmt = opts_.momentum;
@@ -151,7 +152,7 @@ class AffineTransform : public TrainableLayer {
       AdagradScaleCompute(bias_corr_accu_scale,bias_corr_accu);
       // update the parameters
       linearity_.AddMatMatElements(-lr, linearity_corr_accu_scale, linearity_corr_, 1.0);
-      bias_.AddMatMatElements(-lr, bias_corr_accu_scale, linearity_corr_, 1.0);
+      bias_.AddVecVec(-lr, bias_corr_accu_scale, bias_corr_, 1.0);
     }
   }
   

--- a/src/net/bilstm-layer.h
+++ b/src/net/bilstm-layer.h
@@ -599,23 +599,47 @@ public:
         phole_f_c_bw_.AddVec(-lr, phole_f_c_bw_corr_, 1.0);
         phole_o_c_bw_.AddVec(-lr, phole_o_c_bw_corr_, 1.0);
 
-      } else if (rule==adagrad_update) {
+      } else if (rule==adagrad_update || rule==rmsprop_update) {
 
         if (!adaBuffersInitialized) {
           InitAdaBuffers();
           adaBuffersInitialized=true;
         }
-        /// fw
 
-        // update the accumolators
-        AdagradAccuUpdate(wei_gifo_x_fw_corr_accu, wei_gifo_x_fw_corr_, wei_gifo_x_fw_corr_accu_scale);
-        AdagradAccuUpdate(wei_gifo_m_fw_corr_accu, wei_gifo_m_fw_corr_, wei_gifo_m_fw_corr_accu_scale);
-        AdagradAccuUpdate(bias_fw_corr_accu, bias_fw_corr_, bias_fw_corr_accu_scale);
-        AdagradAccuUpdate(phole_i_c_fw_corr_accu, phole_i_c_fw_corr_, phole_i_c_fw_corr_accu_scale);
-        AdagradAccuUpdate(phole_f_c_fw_corr_accu, phole_f_c_fw_corr_, phole_f_c_fw_corr_accu_scale);
-        AdagradAccuUpdate(phole_o_c_fw_corr_accu, phole_o_c_fw_corr_, phole_o_c_fw_corr_accu_scale);
+        if (rule==adagrad_update)
+        {
+          // update the accumolators for fw
+          AdagradAccuUpdate(wei_gifo_x_fw_corr_accu, wei_gifo_x_fw_corr_, wei_gifo_x_fw_corr_accu_scale);
+          AdagradAccuUpdate(wei_gifo_m_fw_corr_accu, wei_gifo_m_fw_corr_, wei_gifo_m_fw_corr_accu_scale);
+          AdagradAccuUpdate(bias_fw_corr_accu, bias_fw_corr_, bias_fw_corr_accu_scale);
+          AdagradAccuUpdate(phole_i_c_fw_corr_accu, phole_i_c_fw_corr_, phole_i_c_fw_corr_accu_scale);
+          AdagradAccuUpdate(phole_f_c_fw_corr_accu, phole_f_c_fw_corr_, phole_f_c_fw_corr_accu_scale);
+          AdagradAccuUpdate(phole_o_c_fw_corr_accu, phole_o_c_fw_corr_, phole_o_c_fw_corr_accu_scale);
+          // update the accumolators for bw
+          AdagradAccuUpdate(wei_gifo_x_bw_corr_accu, wei_gifo_x_bw_corr_, wei_gifo_x_bw_corr_accu_scale);
+          AdagradAccuUpdate(wei_gifo_m_bw_corr_accu, wei_gifo_m_bw_corr_, wei_gifo_m_bw_corr_accu_scale);
+          AdagradAccuUpdate(bias_bw_corr_accu, bias_bw_corr_, bias_bw_corr_accu_scale);
+          AdagradAccuUpdate(phole_i_c_bw_corr_accu, phole_i_c_bw_corr_, phole_i_c_bw_corr_accu_scale);
+          AdagradAccuUpdate(phole_f_c_bw_corr_accu, phole_f_c_bw_corr_, phole_f_c_bw_corr_accu_scale);
+          AdagradAccuUpdate(phole_o_c_bw_corr_accu, phole_o_c_bw_corr_, phole_o_c_bw_corr_accu_scale);
+        }else {
+          // update the accumolators for fw
+          RMSPropAccuUpdate(wei_gifo_x_fw_corr_accu, wei_gifo_x_fw_corr_, wei_gifo_x_fw_corr_accu_scale);
+          RMSPropAccuUpdate(wei_gifo_m_fw_corr_accu, wei_gifo_m_fw_corr_, wei_gifo_m_fw_corr_accu_scale);
+          RMSPropAccuUpdate(bias_fw_corr_accu, bias_fw_corr_, bias_fw_corr_accu_scale);
+          RMSPropAccuUpdate(phole_i_c_fw_corr_accu, phole_i_c_fw_corr_, phole_i_c_fw_corr_accu_scale);
+          RMSPropAccuUpdate(phole_f_c_fw_corr_accu, phole_f_c_fw_corr_, phole_f_c_fw_corr_accu_scale);
+          RMSPropAccuUpdate(phole_o_c_fw_corr_accu, phole_o_c_fw_corr_, phole_o_c_fw_corr_accu_scale);
+          // update the accumolators for bw
+          RMSPropAccuUpdate(wei_gifo_x_bw_corr_accu, wei_gifo_x_bw_corr_, wei_gifo_x_bw_corr_accu_scale);
+          RMSPropAccuUpdate(wei_gifo_m_bw_corr_accu, wei_gifo_m_bw_corr_, wei_gifo_m_bw_corr_accu_scale);
+          RMSPropAccuUpdate(bias_bw_corr_accu, bias_bw_corr_, bias_bw_corr_accu_scale);
+          RMSPropAccuUpdate(phole_i_c_bw_corr_accu, phole_i_c_bw_corr_, phole_i_c_bw_corr_accu_scale);
+          RMSPropAccuUpdate(phole_f_c_bw_corr_accu, phole_f_c_bw_corr_, phole_f_c_bw_corr_accu_scale);
+          RMSPropAccuUpdate(phole_o_c_bw_corr_accu, phole_o_c_bw_corr_, phole_o_c_bw_corr_accu_scale);
+        }
 
-        // calculate 1.0 / sqrt(accu + epsilon)
+        // calculate 1.0 / sqrt(accu + epsilon) for fw
         AdagradScaleCompute(wei_gifo_x_fw_corr_accu_scale,wei_gifo_x_fw_corr_accu);
         AdagradScaleCompute(wei_gifo_m_fw_corr_accu_scale,wei_gifo_m_fw_corr_accu);
         AdagradScaleCompute(bias_fw_corr_accu_scale,bias_fw_corr_accu);
@@ -623,25 +647,7 @@ public:
         AdagradScaleCompute(phole_f_c_fw_corr_accu_scale,phole_f_c_fw_corr_accu);
         AdagradScaleCompute(phole_o_c_fw_corr_accu_scale,phole_o_c_fw_corr_accu);
 
-        // update the parameters
-        wei_gifo_x_fw_.AddMatMatElements(-lr, wei_gifo_x_fw_corr_accu_scale, wei_gifo_x_fw_corr_, 1.0);
-        wei_gifo_m_fw_.AddMatMatElements(-lr, wei_gifo_m_fw_corr_accu_scale, wei_gifo_m_fw_corr_, 1.0);
-        bias_fw_.AddVecVec(-lr, bias_fw_corr_accu_scale, bias_fw_corr_, 1.0);
-        phole_i_c_fw_.AddVecVec(-lr, phole_i_c_fw_corr_accu_scale, phole_i_c_fw_corr_, 1.0);
-        phole_f_c_fw_.AddVecVec(-lr, phole_f_c_fw_corr_accu_scale, phole_f_c_fw_corr_, 1.0);
-        phole_o_c_fw_.AddVecVec(-lr, phole_o_c_fw_corr_accu_scale, phole_o_c_fw_corr_, 1.0);
-
-        /// bw
-
-        // update the accumolators
-        AdagradAccuUpdate(wei_gifo_x_bw_corr_accu, wei_gifo_x_bw_corr_, wei_gifo_x_bw_corr_accu_scale);
-        AdagradAccuUpdate(wei_gifo_m_bw_corr_accu, wei_gifo_m_bw_corr_, wei_gifo_m_bw_corr_accu_scale);
-        AdagradAccuUpdate(bias_bw_corr_accu, bias_bw_corr_, bias_bw_corr_accu_scale);
-        AdagradAccuUpdate(phole_i_c_bw_corr_accu, phole_i_c_bw_corr_, phole_i_c_bw_corr_accu_scale);
-        AdagradAccuUpdate(phole_f_c_bw_corr_accu, phole_f_c_bw_corr_, phole_f_c_bw_corr_accu_scale);
-        AdagradAccuUpdate(phole_o_c_bw_corr_accu, phole_o_c_bw_corr_, phole_o_c_bw_corr_accu_scale);
-
-        // calculate 1.0 / sqrt(accu + epsilon)
+         // calculate 1.0 / sqrt(accu + epsilon) for bw
         AdagradScaleCompute(wei_gifo_x_bw_corr_accu_scale,wei_gifo_x_bw_corr_accu);
         AdagradScaleCompute(wei_gifo_m_bw_corr_accu_scale,wei_gifo_m_bw_corr_accu);
         AdagradScaleCompute(bias_bw_corr_accu_scale,bias_bw_corr_accu);
@@ -649,17 +655,22 @@ public:
         AdagradScaleCompute(phole_f_c_bw_corr_accu_scale,phole_f_c_bw_corr_accu);
         AdagradScaleCompute(phole_o_c_bw_corr_accu_scale,phole_o_c_bw_corr_accu);
 
-        // update the parameters
+        // update the parameters for fw
+        wei_gifo_x_fw_.AddMatMatElements(-lr, wei_gifo_x_fw_corr_accu_scale, wei_gifo_x_fw_corr_, 1.0);
+        wei_gifo_m_fw_.AddMatMatElements(-lr, wei_gifo_m_fw_corr_accu_scale, wei_gifo_m_fw_corr_, 1.0);
+        bias_fw_.AddVecVec(-lr, bias_fw_corr_accu_scale, bias_fw_corr_, 1.0);
+        phole_i_c_fw_.AddVecVec(-lr, phole_i_c_fw_corr_accu_scale, phole_i_c_fw_corr_, 1.0);
+        phole_f_c_fw_.AddVecVec(-lr, phole_f_c_fw_corr_accu_scale, phole_f_c_fw_corr_, 1.0);
+        phole_o_c_fw_.AddVecVec(-lr, phole_o_c_fw_corr_accu_scale, phole_o_c_fw_corr_, 1.0);
+
+        // update the parameters for bw
         wei_gifo_x_bw_.AddMatMatElements(-lr, wei_gifo_x_bw_corr_accu_scale, wei_gifo_x_bw_corr_, 1.0);
         wei_gifo_m_bw_.AddMatMatElements(-lr, wei_gifo_m_bw_corr_accu_scale, wei_gifo_m_bw_corr_, 1.0);
         bias_bw_.AddVecVec(-lr, bias_bw_corr_accu_scale, bias_bw_corr_, 1.0);
         phole_i_c_bw_.AddVecVec(-lr, phole_i_c_bw_corr_accu_scale, phole_i_c_bw_corr_, 1.0);
         phole_f_c_bw_.AddVecVec(-lr, phole_f_c_bw_corr_accu_scale, phole_f_c_bw_corr_, 1.0);
         phole_o_c_bw_.AddVecVec(-lr, phole_o_c_bw_corr_accu_scale, phole_o_c_bw_corr_, 1.0);
-
       }
-  
-
     }
 
     void Scale(BaseFloat scale) {

--- a/src/net/bilstm-layer.h
+++ b/src/net/bilstm-layer.h
@@ -230,6 +230,23 @@ public:
   
     // print statistics of the gradients buffer
     std::string InfoGradient() const {
+        std::string extra = std::string("");
+        if (adaBuffersInitialized)
+        {
+            extra += "\n  wei_gifo_x_fw_corr_accu  "   + MomentStatistics(wei_gifo_x_fw_corr_accu) +
+            "\n  wei_gifo_m_fw_corr_accu  "   + MomentStatistics(wei_gifo_m_fw_corr_accu) +
+            "\n  bias_fw_corr_accu  "         + MomentStatistics(bias_fw_corr_accu) +
+            "\n  phole_i_c_fw_corr_accu  "      + MomentStatistics(phole_i_c_fw_corr_accu) +
+            "\n  phole_f_c_fw_corr_accu  "      + MomentStatistics(phole_f_c_fw_corr_accu) +
+            "\n  phole_o_c_fw_corr_accu  "      + MomentStatistics(phole_o_c_fw_corr_accu) +
+            "\n  wei_gifo_x_bw_corr_accu  "   + MomentStatistics(wei_gifo_x_bw_corr_accu) +
+            "\n  wei_gifo_m_bw_corr_accu  "   + MomentStatistics(wei_gifo_m_bw_corr_accu) +
+            "\n  bias_bw_corr_accu  "         + MomentStatistics(bias_bw_corr_accu) +
+            "\n  phole_i_c_bw_corr_accu  "      + MomentStatistics(phole_i_c_bw_corr_accu) +
+            "\n  phole_f_c_bw_corr_accu  "      + MomentStatistics(phole_f_c_bw_corr_accu) +
+            "\n  phole_o_c_bw_corr_accu  "      + MomentStatistics(phole_o_c_bw_corr_accu);          
+        }
+
         return std::string("    ") +
             "\n  wei_gifo_x_fw_corr_  "   + MomentStatistics(wei_gifo_x_fw_corr_) +
             "\n  wei_gifo_m_fw_corr_  "   + MomentStatistics(wei_gifo_m_fw_corr_) +
@@ -242,7 +259,7 @@ public:
             "\n  bias_bw_corr_  "         + MomentStatistics(bias_bw_corr_) +
             "\n  phole_i_c_bw_corr_  "      + MomentStatistics(phole_i_c_bw_corr_) +
             "\n  phole_f_c_bw_corr_  "      + MomentStatistics(phole_f_c_bw_corr_) +
-            "\n  phole_o_c_bw_corr_  "      + MomentStatistics(phole_o_c_bw_corr_);
+            "\n  phole_o_c_bw_corr_  "      + MomentStatistics(phole_o_c_bw_corr_) + extra;
     }
 
     // the feedforward pass

--- a/src/net/ctc-loss.cc
+++ b/src/net/ctc-loss.cc
@@ -84,7 +84,7 @@ void Ctc::Eval(const CuMatrixBase<BaseFloat> &net_out, const std::vector<int32> 
   // progressive reporting
   {
     if (sequences_progress_ >= report_step_) {
-      KALDI_VLOG(1) << "After " << sequences_num_ << " sequences (" << frames_/(100.0 * 3600) << "Hr): "
+      KALDI_VLOG(1) << "After " << sequences_num_ << " sequences (" << frames_/(frames_per_sec_ * 3600) << "Hr): "
                     << "Obj(log[Pzx]) = " << obj_progress_/sequences_progress_
                     << "   TokenAcc = " << 100.0*(1.0 - error_num_progress_/ref_num_progress_) << "%";
       // reset

--- a/src/net/ctc-loss.h
+++ b/src/net/ctc-loss.h
@@ -30,7 +30,7 @@ class Ctc {
  public:
   Ctc() : frames_(0), sequences_num_(0), ref_num_(0), error_num_(0), 
           frames_progress_(0), ref_num_progress_(0), error_num_progress_(0),
-          sequences_progress_(0), obj_progress_(0.0), report_step_(100) { }
+          sequences_progress_(0), obj_progress_(0.0), report_step_(100), frames_per_sec_(100.0) { }
   ~Ctc() { }
 
   /// CTC training over a single sequence from the labels. The errors are returned to [diff]
@@ -53,6 +53,9 @@ class Ctc {
   /// Set the step of reporting
   void SetReportStep(int32 report_step) { report_step_ = report_step;  }
 
+  /// Set frames per second
+  void SetFramesPerSec(float frames_per_sec) { frames_per_sec_ = frames_per_sec;  }
+
   /// Generate string with report
   std::string Report();
 
@@ -73,6 +76,7 @@ class Ctc {
   double obj_progress_;              // registry for the optimization objective
 
   int32 report_step_;                // report obj and accuracy every so many sequences/utterances
+  float frames_per_sec_;
 
   std::vector<int32> label_expand_;  // expanded version of the label sequence
   CuMatrix<BaseFloat> alpha_;        // alpha values

--- a/src/net/lstm-layer.h
+++ b/src/net/lstm-layer.h
@@ -337,21 +337,30 @@ public:
         phole_i_c_.AddVec(-lr, phole_i_c_corr_, 1.0);
         phole_f_c_.AddVec(-lr, phole_f_c_corr_, 1.0);
         phole_o_c_.AddVec(-lr, phole_o_c_corr_, 1.0); 
-      }
-      else if (rule==adagrad_update) {
+      } 
+      else if (rule==adagrad_update || rule==rmsprop_update) {
         if (!adaBuffersInitialized) {
           InitAdaBuffers();
           adaBuffersInitialized=true;
         }
 
-
         // update the accumolators
-        AdagradAccuUpdate(wei_gifo_x_corr_accu, wei_gifo_x_corr_, wei_gifo_x_corr_accu_scale);
-        AdagradAccuUpdate(wei_gifo_m_corr_accu, wei_gifo_m_corr_, wei_gifo_m_corr_accu_scale); 
-        AdagradAccuUpdate(bias_corr_accu, bias_corr_, bias_corr_accu_scale);
-        AdagradAccuUpdate(phole_i_c_corr_accu, phole_i_c_corr_, phole_i_c_corr_accu_scale);
-        AdagradAccuUpdate(phole_f_c_corr_accu, phole_f_c_corr_, phole_f_c_corr_accu_scale);
-        AdagradAccuUpdate(phole_o_c_corr_accu, phole_o_c_corr_, phole_o_c_corr_accu_scale);
+        if (rule==adagrad_update)
+        {
+          AdagradAccuUpdate(wei_gifo_x_corr_accu, wei_gifo_x_corr_, wei_gifo_x_corr_accu_scale);
+          AdagradAccuUpdate(wei_gifo_m_corr_accu, wei_gifo_m_corr_, wei_gifo_m_corr_accu_scale); 
+          AdagradAccuUpdate(bias_corr_accu, bias_corr_, bias_corr_accu_scale);
+          AdagradAccuUpdate(phole_i_c_corr_accu, phole_i_c_corr_, phole_i_c_corr_accu_scale);
+          AdagradAccuUpdate(phole_f_c_corr_accu, phole_f_c_corr_, phole_f_c_corr_accu_scale);
+          AdagradAccuUpdate(phole_o_c_corr_accu, phole_o_c_corr_, phole_o_c_corr_accu_scale);
+        } else {
+          RMSPropAccuUpdate(wei_gifo_x_corr_accu, wei_gifo_x_corr_, wei_gifo_x_corr_accu_scale);
+          RMSPropAccuUpdate(wei_gifo_m_corr_accu, wei_gifo_m_corr_, wei_gifo_m_corr_accu_scale); 
+          RMSPropAccuUpdate(bias_corr_accu, bias_corr_, bias_corr_accu_scale);
+          RMSPropAccuUpdate(phole_i_c_corr_accu, phole_i_c_corr_, phole_i_c_corr_accu_scale);
+          RMSPropAccuUpdate(phole_f_c_corr_accu, phole_f_c_corr_, phole_f_c_corr_accu_scale);
+          RMSPropAccuUpdate(phole_o_c_corr_accu, phole_o_c_corr_, phole_o_c_corr_accu_scale);
+        }
        
         // calculate 1.0 / sqrt(accu + epsilon)
         AdagradScaleCompute(wei_gifo_x_corr_accu_scale,wei_gifo_x_corr_accu);

--- a/src/net/lstm-layer.h
+++ b/src/net/lstm-layer.h
@@ -77,7 +77,7 @@ public:
       max_grad_ = max_grad;
     }
 
-    void InitAdaBuffer () {
+    void InitAdaBuffers () {
       //for Ada:
       wei_gifo_m_corr_accu.Resize(4 * cell_dim_, cell_dim_);  wei_gifo_m_corr_accu.Set(0.0);
       wei_gifo_m_corr_accu_scale.Resize(4 * cell_dim_, cell_dim_);

--- a/src/net/lstm-layer.h
+++ b/src/net/lstm-layer.h
@@ -124,7 +124,7 @@ public:
       phole_f_c_corr_ = phole_f_c_; phole_f_c_corr_.SetZero();
       phole_o_c_corr_ = phole_o_c_; phole_o_c_corr_.SetZero();
 
-      adaBuffersInitialized = true;
+      adaBuffersInitialized = false;
     }
 
     void WriteData(std::ostream &os, bool binary) const {

--- a/src/net/lstm-layer.h
+++ b/src/net/lstm-layer.h
@@ -29,8 +29,8 @@ class Lstm : public TrainableLayer {
 public:
     Lstm(int32 input_dim, int32 output_dim) :
         TrainableLayer(input_dim, output_dim),
-        cell_dim_(output_dim),
-        learn_rate_coef_(1.0), max_grad_(0.0)
+        cell_dim_(output_dim), learn_rate_coef_(1.0), 
+        max_grad_(0.0), adaBuffersInitialized(false)
     { }
 
     ~Lstm()
@@ -60,39 +60,42 @@ public:
 
       // initialize weights and biases
       wei_gifo_x_.Resize(4 * cell_dim_, input_dim_); wei_gifo_x_.InitRandUniform(param_range);
-      //for Ada:
-      wei_gifo_x_corr_accu.Resize(4 * cell_dim_, input_dim_); wei_gifo_x_corr_accu.Set(0.0);
-      wei_gifo_x_corr_accu_scale.Resize(4 * cell_dim_, input_dim_);
       // the weights connecting momory cell outputs with the units/gates
       wei_gifo_m_.Resize(4 * cell_dim_, cell_dim_);  wei_gifo_m_.InitRandUniform(param_range);
-      //for Ada:
-      wei_gifo_m_corr_accu.Resize(4 * cell_dim_, cell_dim_);  wei_gifo_m_corr_accu.Set(0.0);
-      wei_gifo_m_corr_accu_scale.Resize(4 * cell_dim_, cell_dim_);
       // the bias for the units/gates
       bias_.Resize(4 * cell_dim_); bias_.InitRandUniform(param_range);
       if (fgate_bias_init != 0.0) {   // reset the bias of the forget gates
         bias_.Range(2 * cell_dim_, cell_dim_).Set(fgate_bias_init);
       }
-      //for Ada:
-      bias_corr_accu.Resize(4 * cell_dim_);  bias_corr_accu.Set(0.0);
-      bias_corr_accu_scale.Resize(4 * cell_dim_);
-
       // peephole connections for i, f, and o, with diagonal matrices (vectors)
       phole_i_c_.Resize(cell_dim_); phole_i_c_.InitRandUniform(param_range);
-      phole_i_c_corr_accu.Resize(cell_dim_); phole_i_c_corr_accu.Set(0.0);
-      phole_i_c_corr_accu_scale.Resize(cell_dim_); 
-
       phole_f_c_.Resize(cell_dim_); phole_f_c_.InitRandUniform(param_range);
-      phole_f_c_corr_accu.Resize(cell_dim_); phole_f_c_corr_accu.Set(0.0);
-      phole_f_c_corr_accu_scale.Resize(cell_dim_);
-
       phole_o_c_.Resize(cell_dim_); phole_o_c_.InitRandUniform(param_range);
-      phole_o_c_corr_accu.Resize(cell_dim_); phole_o_c_corr_accu.Set(0.0);
-      phole_o_c_corr_accu_scale.Resize(cell_dim_);
 
       //
       learn_rate_coef_ = learn_rate_coef;
       max_grad_ = max_grad;
+    }
+
+    void InitAdaBuffer () {
+      //for Ada:
+      wei_gifo_m_corr_accu.Resize(4 * cell_dim_, cell_dim_);  wei_gifo_m_corr_accu.Set(0.0);
+      wei_gifo_m_corr_accu_scale.Resize(4 * cell_dim_, cell_dim_);
+      
+      wei_gifo_x_corr_accu.Resize(4 * cell_dim_, input_dim_); wei_gifo_x_corr_accu.Set(0.0);
+      wei_gifo_x_corr_accu_scale.Resize(4 * cell_dim_, input_dim_);
+      
+      bias_corr_accu.Resize(4 * cell_dim_);  bias_corr_accu.Set(0.0);
+      bias_corr_accu_scale.Resize(4 * cell_dim_);
+
+      phole_i_c_corr_accu.Resize(cell_dim_); phole_i_c_corr_accu.Set(0.0);
+      phole_i_c_corr_accu_scale.Resize(cell_dim_); 
+
+      phole_f_c_corr_accu.Resize(cell_dim_); phole_f_c_corr_accu.Set(0.0);
+      phole_f_c_corr_accu_scale.Resize(cell_dim_);
+      
+      phole_o_c_corr_accu.Resize(cell_dim_); phole_o_c_corr_accu.Set(0.0);
+      phole_o_c_corr_accu_scale.Resize(cell_dim_);
     }
 
     void ReadData(std::istream &is, bool binary) {
@@ -120,6 +123,8 @@ public:
       phole_i_c_corr_ = phole_i_c_; phole_i_c_corr_.SetZero();
       phole_f_c_corr_ = phole_f_c_; phole_f_c_corr_.SetZero();
       phole_o_c_corr_ = phole_o_c_; phole_o_c_corr_.SetZero();
+
+      adaBuffersInitialized = true;
     }
 
     void WriteData(std::ostream &os, bool binary) const {
@@ -334,6 +339,12 @@ public:
         phole_o_c_.AddVec(-lr, phole_o_c_corr_, 1.0); 
       }
       else if (rule==adagrad_update) {
+        if (!adaBuffersInitialized) {
+          InitAdaBuffers();
+          adaBuffersInitialized=true;
+        }
+
+
         // update the accumolators
         AdagradAccuUpdate(wei_gifo_x_corr_accu, wei_gifo_x_corr_, wei_gifo_x_corr_accu_scale);
         AdagradAccuUpdate(wei_gifo_m_corr_accu, wei_gifo_m_corr_, wei_gifo_m_corr_accu_scale); 
@@ -411,6 +422,7 @@ protected:
     int32 cell_dim_;
     BaseFloat learn_rate_coef_;
     BaseFloat max_grad_;
+    bool adaBuffersInitialized;
 
     // parameters of the forward layer
     CuMatrix<BaseFloat> wei_gifo_x_;

--- a/src/net/lstm-layer.h
+++ b/src/net/lstm-layer.h
@@ -60,17 +60,35 @@ public:
 
       // initialize weights and biases
       wei_gifo_x_.Resize(4 * cell_dim_, input_dim_); wei_gifo_x_.InitRandUniform(param_range);
+      //for Ada:
+      wei_gifo_x_accu.Resize(4 * cell_dim_, input_dim_); wei_gifo_x_.Set(0.0);
+      wei_gifo_x_accu_scale.Resize(4 * cell_dim_, input_dim_);
       // the weights connecting momory cell outputs with the units/gates
       wei_gifo_m_.Resize(4 * cell_dim_, cell_dim_);  wei_gifo_m_.InitRandUniform(param_range);
+      //for Ada:
+      wei_gifo_m_accu.Resize(4 * cell_dim_, cell_dim_);  wei_gifo_m_accu.Set(0.0);
+      wei_gifo_m_accu_scale.Resize(4 * cell_dim_, cell_dim_);
       // the bias for the units/gates
       bias_.Resize(4 * cell_dim_); bias_.InitRandUniform(param_range);
       if (fgate_bias_init != 0.0) {   // reset the bias of the forget gates
         bias_.Range(2 * cell_dim_, cell_dim_).Set(fgate_bias_init);
       }
+      //for Ada:
+      bias_accu.Resize(4 * cell_dim_);  bias_accu.Set(0.0);
+      bias_accu_scale.Resize(4 * cell_dim_);
+
       // peephole connections for i, f, and o, with diagonal matrices (vectors)
       phole_i_c_.Resize(cell_dim_); phole_i_c_.InitRandUniform(param_range);
+      phole_i_c_accu.Resize(cell_dim_); phole_i_c_accu.Set(0.0);
+      phole_i_c_accu_scale.Resize(cell_dim_); 
+
       phole_f_c_.Resize(cell_dim_); phole_f_c_.InitRandUniform(param_range);
+      phole_f_c_accu.Resize(cell_dim_); phole_f_c_accu.Set(0.0);
+      phole_f_c_accu_scale.Resize(cell_dim_);
+
       phole_o_c_.Resize(cell_dim_); phole_o_c_.InitRandUniform(param_range);
+      phole_o_c_accu.Resize(cell_dim_); phole_o_c_accu.Set(0.0);
+      phole_o_c_accu_scale.Resize(cell_dim_);
 
       //
       learn_rate_coef_ = learn_rate_coef;
@@ -290,7 +308,7 @@ public:
         phole_o_c_corr_.AddDiagMatMat(1.0, DO.RowRange(1,T), kTrans, YC.RowRange(1,T), kNoTrans, mmt);
     }
 
-    void Update(const CuMatrixBase<BaseFloat> &input, const CuMatrixBase<BaseFloat> &diff) {
+    void Update(const CuMatrixBase<BaseFloat> &input, const CuMatrixBase<BaseFloat> &diff, UpdateRule rule) {
       // clip gradients 
       if (max_grad_ > 0) {
         wei_gifo_x_corr_.ApplyFloor(-max_grad_); wei_gifo_x_corr_.ApplyCeiling(max_grad_);
@@ -302,14 +320,43 @@ public:
       }
 
       // update parameters
-      const BaseFloat lr = opts_.learn_rate * learn_rate_coef_;
-
-      wei_gifo_x_.AddMat(-lr, wei_gifo_x_corr_);
-      wei_gifo_m_.AddMat(-lr, wei_gifo_m_corr_);
-      bias_.AddVec(-lr, bias_corr_, 1.0);
-      phole_i_c_.AddVec(-lr, phole_i_c_corr_, 1.0);
-      phole_f_c_.AddVec(-lr, phole_f_c_corr_, 1.0);
-      phole_o_c_.AddVec(-lr, phole_o_c_corr_, 1.0);
+      const BaseFloat lr = opts_.learn_rate;
+      
+      if (rule==sgd_update) {
+        lr *= learn_rate_coef_;
+        
+        wei_gifo_x_.AddMat(-lr*wei_gifo_x_scale, wei_gifo_x_corr_);
+        wei_gifo_m_.AddMat(-lr*wei_gifo_m_scale, wei_gifo_m_corr_);
+        bias_.AddVec(-lr*bias_scale, bias_corr_, 1.0);
+        phole_i_c_.AddVec(-lr*phole_i_c_scale, phole_i_c_corr_, 1.0);
+        phole_f_c_.AddVec(-lr*phole_f_c_scale, phole_f_c_corr_, 1.0);
+        phole_o_c_.AddVec(-lr*phole_o_c_scale, phole_o_c_corr_, 1.0);
+      }
+      else if (rule==adagrad_update) {
+        // update the accumolators
+        AdagradAccuUpdate(wei_gifo_x_corr_accu, wei_gifo_x_corr_, wei_gifo_x_corr_accu_scale);
+        AdagradAccuUpdate(wei_gifo_m_corr_accu, wei_gifo_m_corr_, wei_gifo_m_corr_accu_scale); 
+        AdagradAccuUpdate(bias_corr_accu, bias_corr_, bias_corr_accu_scale);
+        AdagradAccuUpdate(phole_i_c_corr_accu, phole_i_c_corr_, phole_i_c_corr_accu_scale);
+        AdagradAccuUpdate(phole_f_c_corr_accu, phole_f_c_corr_, phole_f_c_corr_accu_scale);
+        AdagradAccuUpdate(phole_o_c_corr_accu, phole_o_c_corr_, phole_o_c_corr_accu_scale);
+       
+        // calculate 1.0 / sqrt(accu + epsilon)
+        AdagradScaleCompute(wei_gifo_x_corr_accu_scale,wei_gifo_x_corr_accu);
+        AdagradScaleCompute(wei_gifo_m_corr_accu_scale,wei_gifo_m_corr_accu);
+        AdagradScaleCompute(bias_corr_accu_scale,bias_corr_accu);
+        AdagradScaleCompute(phole_i_c_corr_accu_scale,phole_i_c_corr_accu);
+        AdagradScaleCompute(phole_f_c_corr_accu_scale,phole_f_c_corr_accu);
+        AdagradScaleCompute(phole_o_c_corr_accu_scale,phole_o_c_corr_accu);
+        
+        // update the parameters
+        wei_gifo_x_.AddMatMatElements(-lr, wei_gifo_x_corr_accu_scale, wei_gifo_x_corr_, 1.0);
+        wei_gifo_m_.AddMatMatElements(-lr, wei_gifo_m_corr_accu_scale, wei_gifo_m_corr_, 1.0);
+        bias_.AddVecVec(-lr, bias_corr_accu_scale, bias_corr_, 1.0);
+        phole_i_c_.AddVecVec(-lr, phole_i_c_corr_accu_scale, phole_i_c_corr_, 1.0);
+        phole_f_c_.AddVecVec(-lr, phole_f_c_corr_accu_scale, phole_f_c_corr_, 1.0);
+        phole_o_c_.AddVecVec(-lr, phole_o_c_corr_accu_scale, phole_o_c_corr_, 1.0);
+      }
     }
 
     void Scale(BaseFloat scale) {
@@ -378,6 +425,22 @@ protected:
     CuVector<BaseFloat> phole_i_c_corr_;
     CuVector<BaseFloat> phole_f_c_corr_;
     CuVector<BaseFloat> phole_o_c_corr_;
+
+    // accumolators for e.g. AdaGrad
+    CuMatrix<BaseFloat> wei_gifo_x_corr_accu;
+    CuMatrix<BaseFloat> wei_gifo_m_corr_accu;
+    CuVector<BaseFloat> bias_corr_accu;
+    CuVector<BaseFloat> phole_i_c_corr_accu;
+    CuVector<BaseFloat> phole_f_c_corr_accu;
+    CuVector<BaseFloat> phole_o_c_corr_accu;
+
+    // for scale computation, e.g. AdaGrad
+    CuMatrix<BaseFloat> wei_gifo_x_corr_accu_scale;
+    CuMatrix<BaseFloat> wei_gifo_m_corr_accu_scale;
+    CuVector<BaseFloat> bias_corr_accu_scale;
+    CuVector<BaseFloat> phole_i_c_corr_accu_scale;
+    CuVector<BaseFloat> phole_f_c_corr_accu_scale;
+    CuVector<BaseFloat> phole_o_c_corr_accu_scale;
 
     // propagation buffer
     CuMatrix<BaseFloat> propagate_buf_;

--- a/src/net/net.cc
+++ b/src/net/net.cc
@@ -445,6 +445,9 @@ void Net::SetUpdateAlgorithm(std::string opt) {
   }else if (opt.compare("Adagrad")==0) {
     KALDI_LOG << "Selecting Adagrad as optimization algorithm.";
     update_algorithm=adagrad_update;
+  }else if (opt.compare("RMSProp")==0) {
+    KALDI_LOG << "Selecting RMSProp as optimization algorithm.";
+    update_algorithm=rmsprop_update;
   }else{
     KALDI_ERR << "This optimization algorithm is unsupported: " << opt;
     KALDI_LOG << "Selecting SGD with momentum as optimization algorithm.";

--- a/src/net/net.cc
+++ b/src/net/net.cc
@@ -100,7 +100,7 @@ void Net::Backpropagate(const CuMatrixBase<BaseFloat> &out_diff, CuMatrix<BaseFl
                               backpropagate_buf_[i+1], &backpropagate_buf_[i]);
     if (layers_[i]->IsTrainable()) {
       TrainableLayer *tl = dynamic_cast<TrainableLayer*>(layers_[i]);
-      tl->Update(propagate_buf_[i], backpropagate_buf_[i+1]);
+      tl->Update(propagate_buf_[i], backpropagate_buf_[i+1], update_algorithm);
     }
   }
   // eventually export the derivative
@@ -438,6 +438,14 @@ void Net::Destroy() {
   backpropagate_buf_.resize(0);
 }
 
+void Net::SetUpdateAlgorithm(std::string opt) {
+  if (opt == "SGD")
+  {
+    update_algorithm=sgd_update;
+  }else if (opt == "Adagrad") {
+    update_algorithm=adagrad_update;
+  }
+}
 
 void Net::SetTrainOptions(const NetTrainOptions& opts) {
   opts_ = opts;

--- a/src/net/net.cc
+++ b/src/net/net.cc
@@ -439,11 +439,16 @@ void Net::Destroy() {
 }
 
 void Net::SetUpdateAlgorithm(std::string opt) {
-  if (opt == "SGD")
-  {
+  if (opt.compare("SGD")==0) {
+    KALDI_LOG << "Selecting SGD with momentum as optimization algorithm.";
     update_algorithm=sgd_update;
-  }else if (opt == "Adagrad") {
+  }else if (opt.compare("Adagrad")==0) {
+    KALDI_LOG << "Selecting Adagrad as optimization algorithm.";
     update_algorithm=adagrad_update;
+  }else{
+    KALDI_ERR << "This optimization algorithm is unsupported: " << opt;
+    KALDI_LOG << "Selecting SGD with momentum as optimization algorithm.";
+    update_algorithm=sgd_update;
   }
 }
 

--- a/src/net/net.h
+++ b/src/net/net.h
@@ -43,6 +43,7 @@ class Net {
   ~Net(); 
 
  public:
+  
   /// Perform forward pass through the network
   void Propagate(const CuMatrixBase<BaseFloat> &in, CuMatrix<BaseFloat> *out); 
   /// Perform backward pass through the network
@@ -64,7 +65,7 @@ class Net {
   /// Sets the c'th layer to "layer", taking ownership of the pointer
   /// and deleting the corresponding one that we own.
   void SetLayer(int32 c, Layer *layer);
- 
+  
   /// Remove component
   void RemoveLayer(int32 c);
   void RemoveLastLayer() { RemoveLayer(NumLayers()-1); }
@@ -125,6 +126,9 @@ class Net {
   /// Relese the memory
   void Destroy();
 
+  /// sets the update algorithm that backprogate uses through the network
+  void SetUpdateAlgorithm(std::string opt);
+
   /// Set training hyper-parameters to the network and its TrainableLayer(s)
   void SetTrainOptions(const NetTrainOptions& opts);
   /// Get training hyper-parameters from the network
@@ -149,6 +153,8 @@ class Net {
 
   /// Option class with hyper-parameters passed to TrainableLayer(s)
   NetTrainOptions opts_;
+
+  UpdateRule update_algorithm;
 };
   
 

--- a/src/net/train-opts.h
+++ b/src/net/train-opts.h
@@ -30,20 +30,26 @@ struct NetTrainOptions {
   // option declaration
   BaseFloat learn_rate;
   BaseFloat momentum;
+  BaseFloat adagrad_epsilon;
+  BaseFloat rmsprop_rho;
   // default values
   NetTrainOptions() : learn_rate(0.008),
-                      momentum(0.0)
+                      momentum(0.0),
+                      adagrad_epsilon(1e-6)
                       {}
   // register options
   void Register(OptionsItf *po) {
     po->Register("learn-rate", &learn_rate, "Learning rate");
     po->Register("momentum", &momentum, "Momentum");
+    po->Register("adagrad-epsilon", &adagrad_epsilon, "Epsilon for numerical stability for all adaptive optimizers (Adagrad, RMSProp)");
+
   }
   // print for debug purposes
   friend std::ostream& operator<<(std::ostream& os, const NetTrainOptions& opts) {
     os << "TrainOptions : "
        << "learn_rate" << opts.learn_rate << ", "
-       << "momentum" << opts.momentum;
+       << "momentum" << opts.momentum << ", "
+       << "adagrad_epsilon" << opts.adagrad_epsilon;
     return os;
   }
 };

--- a/src/net/train-opts.h
+++ b/src/net/train-opts.h
@@ -56,7 +56,7 @@ struct NetTrainOptions {
        << "momentum" << opts.momentum << ", "
        << "adagrad_epsilon" << opts.adagrad_epsilon << ", "
        << "rmsprop_rho" << opts.rmsprop_rho << ", "
-       << "rmsprop_one_minus_rho" << rmsprop_one_minus_rho;
+       << "rmsprop_one_minus_rho" << opts.rmsprop_one_minus_rho;
     return os;
   }
 };

--- a/src/net/train-opts.h
+++ b/src/net/train-opts.h
@@ -32,16 +32,21 @@ struct NetTrainOptions {
   BaseFloat momentum;
   BaseFloat adagrad_epsilon;
   BaseFloat rmsprop_rho;
+  BaseFloat rmsprop_one_minus_rho;
+
   // default values
   NetTrainOptions() : learn_rate(0.008),
                       momentum(0.0),
-                      adagrad_epsilon(1e-6)
+                      adagrad_epsilon(1e-6),
+                      rmsprop_rho(0.9),
+                      rmsprop_one_minus_rho(0.1)
                       {}
   // register options
   void Register(OptionsItf *po) {
     po->Register("learn-rate", &learn_rate, "Learning rate");
     po->Register("momentum", &momentum, "Momentum");
     po->Register("adagrad-epsilon", &adagrad_epsilon, "Epsilon for numerical stability for all adaptive optimizers (Adagrad, RMSProp)");
+    po->Register("rms-prop", &adagrad_epsilon, "Rho parameter for RMSProp");
 
   }
   // print for debug purposes
@@ -49,7 +54,8 @@ struct NetTrainOptions {
     os << "TrainOptions : "
        << "learn_rate" << opts.learn_rate << ", "
        << "momentum" << opts.momentum << ", "
-       << "adagrad_epsilon" << opts.adagrad_epsilon;
+       << "adagrad_epsilon" << opts.adagrad_epsilon << ", "
+       << "rmsprop_rho" << opts.rmsprop_rho;
     return os;
   }
 };

--- a/src/net/train-opts.h
+++ b/src/net/train-opts.h
@@ -46,8 +46,8 @@ struct NetTrainOptions {
     po->Register("learn-rate", &learn_rate, "Learning rate");
     po->Register("momentum", &momentum, "Momentum");
     po->Register("adagrad-epsilon", &adagrad_epsilon, "Epsilon for numerical stability for all adaptive optimizers (Adagrad, RMSProp)");
-    po->Register("rms-prop", &adagrad_epsilon, "Rho parameter for RMSProp");
-
+    po->Register("rms-prop-rho", &rmsprop_rho, "Rho parameter for RMSProp");
+    rmsprop_one_minus_rho = 1.0 - rmsprop_rho;
   }
   // print for debug purposes
   friend std::ostream& operator<<(std::ostream& os, const NetTrainOptions& opts) {
@@ -55,7 +55,8 @@ struct NetTrainOptions {
        << "learn_rate" << opts.learn_rate << ", "
        << "momentum" << opts.momentum << ", "
        << "adagrad_epsilon" << opts.adagrad_epsilon << ", "
-       << "rmsprop_rho" << opts.rmsprop_rho;
+       << "rmsprop_rho" << opts.rmsprop_rho << ", "
+       << "rmsprop_one_minus_rho" << rmsprop_one_minus_rho;
     return os;
   }
 };

--- a/src/net/trainable-layer.h
+++ b/src/net/trainable-layer.h
@@ -35,7 +35,7 @@
 
 namespace eesen {
 
-enum UpdateRule {invalid_update=0, sgd_update=1, adagrad_update=2};
+enum UpdateRule {invalid_update=0, sgd_update=1, adagrad_update=2, rmsprop_update=3};
 
 /**
  * Class TrainableLayer is a Layer which has trainable parameters,
@@ -44,7 +44,7 @@ enum UpdateRule {invalid_update=0, sgd_update=1, adagrad_update=2};
 class TrainableLayer : public Layer {
  public: 
   TrainableLayer(int32 input_dim, int32 output_dim)
-    : Layer(input_dim, output_dim), adagrad_epsilon(1e-6) { }
+    : Layer(input_dim, output_dim) { }
   virtual ~TrainableLayer() { }
 
   /// Check if contains trainable parameters 
@@ -82,7 +82,7 @@ class TrainableLayer : public Layer {
     accu_scale.CopyFromMat(accu);
     //accu_scale.Add(adagrad_epsilon);
     //accu_scale.ApplyPow(0.5);
-    accu_scale.ApplySqrt(adagrad_epsilon);
+    accu_scale.ApplySqrt(opts_.adagrad_epsilon);
     accu_scale.InvertElements();
   }
 
@@ -91,7 +91,7 @@ class TrainableLayer : public Layer {
     accu_scale.CopyFromVec(accu);
     //accu_scale.Add(adagrad_epsilon);
     //accu_scale.ApplyPow(0.5);
-    accu_scale.ApplySqrt(adagrad_epsilon);
+    accu_scale.ApplySqrt(opts_.adagrad_epsilon);
     accu_scale.InvertElements();
   }
 
@@ -109,7 +109,6 @@ class TrainableLayer : public Layer {
   }
 
   virtual void InitData(std::istream &is) = 0;
-  BaseFloat adagrad_epsilon=1e-6;
 
  protected:
   /// Option-class with training hyper-parameters

--- a/src/net/trainable-layer.h
+++ b/src/net/trainable-layer.h
@@ -66,7 +66,7 @@ class TrainableLayer : public Layer {
                                 CuMatrixBase<BaseFloat> &grad_tmp) {
     grad_tmp.CopyFromMat(grad);
     grad_tmp.MulElements(grad);
-    accu.AddMat(1.0,grad_tmp);
+    accu.AddMat(1.0, grad_tmp);
   }
 
   /// Compute accu+grad**2 elementwise for vectors
@@ -74,7 +74,25 @@ class TrainableLayer : public Layer {
                                 CuVectorBase<BaseFloat> &grad_tmp) {
     grad_tmp.CopyFromVec(grad);
     grad_tmp.MulElements(grad);
-    accu.AddVec(1.0,grad_tmp);
+    accu.AddVec(1.0, grad_tmp);
+  }
+
+  /// Compute accu_new = rho * accu + (1 - rho) * grad ** 2 elementwise for matrices
+  inline void RMSPropAccuUpdate(CuMatrixBase<BaseFloat> &accu, CuMatrixBase<BaseFloat> &grad, 
+                                CuMatrixBase<BaseFloat> &grad_tmp) {
+    grad_tmp.CopyFromMat(grad);
+    grad_tmp.MulElements(grad);
+    accu.Scale(opts_.rmsprop_rho);
+    accu.AddMat(opts_.rmsprop_one_minus_rho, grad_tmp);
+  }
+
+  /// Compute accu_new = rho * accu + (1 - rho) * grad ** 2 elementwise for vectors
+  inline void RMSPropAccuUpdate(CuVectorBase<BaseFloat> &accu, CuVectorBase<BaseFloat> &grad, 
+                                CuVectorBase<BaseFloat> &grad_tmp) {
+    grad_tmp.CopyFromVec(grad);
+    grad_tmp.MulElements(grad);
+    accu.Scale(opts_.rmsprop_rho);
+    accu.AddVec(opts_.rmsprop_one_minus_rho, grad_tmp);
   }
 
   /// calculate 1.0 / sqrt(accu + epsilon) elementwise for matrices

--- a/src/netbin/train-ctc-parallel.cc
+++ b/src/netbin/train-ctc-parallel.cc
@@ -74,6 +74,9 @@ int main(int argc, char *argv[]) {
     int32 utts_per_avg = 500;
     po.Register("utts-per-avg", &utts_per_avg, "Number of utterances to process per average (default is 250)");
 
+    std::string opt = "SGD";
+    po.Register("opt-algorithm", &opt, "Optimization algorithm (SGD|Adagrad)");
+
     po.Read(argc, argv);
 
     if (po.NumArgs() != 4-(crossvalidate?1:0)) {
@@ -108,6 +111,7 @@ int main(int argc, char *argv[]) {
     Net net;
     net.Read(model_filename);
     net.SetTrainOptions(trn_opts);
+    net.SetUpdateAlgorithm(opt);
 
     eesen::int64 total_frames = 0;
 

--- a/src/netbin/train-ctc-parallel.cc
+++ b/src/netbin/train-ctc-parallel.cc
@@ -75,7 +75,7 @@ int main(int argc, char *argv[]) {
     po.Register("utts-per-avg", &utts_per_avg, "Number of utterances to process per average (default is 250)");
 
     std::string opt = "SGD";
-    po.Register("opt-algorithm", &opt, "Optimization algorithm (SGD|Adagrad)");
+    po.Register("opt-algorithm", &opt, "Optimization algorithm (SGD|Adagrad|RMSProp)");
 
     po.Read(argc, argv);
 


### PR DESCRIPTION
This adds the possibility to train with an adaptive learning rate algorithm. Currently only Adagrad is implemented, since it's the simplest of them, but RMSProp is very similar and can easily be added on top of this. In the current version, a switch is provided to train-ctc-parallel:

po.Register("opt-algorithm", &opt, "Optimization algorithm (SGD|Adagrad)");

so that "--opt-algorithm Adagrad" will run the training with Adagrad.

Even though Adagrad has a very simple formula, a lot of changes were necessary:

(+) I added some missing cudamatrix and cudavector functions to make this possible, but similar functions need to be added for the CPU-only version. With the exception of the sqrt function, these are from Kaldi.
(+) Since each layer has its own update function, all layer types needed to be updated with the Adagrad update code. To keep things manageable though, helper functions have been added to the base class trainable_layer so that all layer types share the update code. But for every variable this is called separately, as with SGD. One accumulator and one temporary variable is added for every gradient matrix and vector in every layer. These are only resized / initialized if Adagrad is chosen as optimization algorithm though and shouldn't take extra space on the GPU if run with SGD. 

I am currently testing with the following parameters (note that Adagrad needs a higher initial learning rate and is run without momentum and I found it helpful to clip gradients more aggressively): 

learn_rate 0.01
momentum 0.0
maxgrad 4.0

This seems to work for me, but needs more testing + a side by side WER comparison with SGD. Would also be interesting to see if the final result is somewhat more robust to the choice of the initial learning rate.

Limitations of the current state of the implementation:
(+) A short coming is that the accumulator is not saved between epochs, resulting in a temporary drop of the accuracy at the beginning of an epoch until the accumulator is re-estimated. Also this makes the learning rate annealing schedule still necessary.
(+) Adagrad is GPU-only at the moment, but since a switch is provided to choose between SGD+momentum and Adagrad, it can still be configured to run on CPU with SGD.
(+) The switch is currently only added to train-ctc-parallel and I've only tested it with the bilstm layers so far.

Would be really cool if someone could try this out! Hopefully all the necessary changes are in this PR. If not, let me know.