### PR TITLE
Import IRSTLM patching script from Kaldi

### DIFF
--- a/tools/extras/install_irstlm.sh
+++ b/tools/extras/install_irstlm.sh
@@ -6,19 +6,19 @@
 # End configuration section
 set -e -o pipefail
 
+
 errcho() { echo "$@" 1>&2; }
 
 errcho "****() Installing IRSTLM"
 
 if [ ! -x ./irstlm ] ; then
-  svn=`which svn`
+  svn=`which git`
   if [ $? != 0 ]  ; then
-    errcho "****() You need to have svn (subversion) installed"
+    errcho "****() You need to have git installed"
     exit 1
   fi
   (
-    svn -r 618 co --non-interactive --trust-server-cert \
-      https://svn.code.sf.net/p/irstlm/code/trunk irstlm
+    git clone https://github.com/irstlm-team/irstlm.git irstlm
   ) || {
     errcho "****() Error getting the IRSTLM sources. The server hosting it"
     errcho "****() might be down."
@@ -35,6 +35,7 @@ fi
   automake --version | grep 1.13.1 >/dev/null && \
          sed s:AM_CONFIG_HEADER:AC_CONFIG_HEADERS: <configure.in >configure.ac;
 
+  patch -p1 < ../extras/irstlm.patch
   ./regenerate-makefiles.sh || ./regenerate-makefiles.sh
 
   ./configure --prefix `pwd`
@@ -43,23 +44,23 @@ fi
 ) || {
   errcho "***() Error compiling IRSTLM. The error messages could help you "
   errcho "***() in figuring what went wrong."
+  exit 1
 }
 
 (
-  [ ! -z ${IRSTLM} ] && \
+  [ ! -z "${IRSTLM}" ] && \
     echo >&2 "IRSTLM variable is aleady defined. Undefining..." && \
     unset IRSTLM
 
   [ -f ./env.sh ] && . ./env.sh
-  [ ! -z ${IRSTLM} ] && \
+  [ ! -z "${IRSTLM}" ] && \
     echo >&2 "IRSTLM config is already in env.sh" && exit
 
-  wd=`pwd`
-  wd=`readlink -f $wd`
+  wd=`pwd -P`
 
   echo "export IRSTLM=$wd/irstlm"
   echo "export PATH=\${PATH}:\${IRSTLM}/bin"
 ) >> env.sh
 
 errcho "***() Installation of IRSTLM finished successfully"
-errcho "***() Please source the tools/env.sh in your path.sh to enable it"
+errcho "***() Please source the tools/extras/env.sh in your path.sh to enable it"

--- a/tools/extras/irstlm.patch
+++ b/tools/extras/irstlm.patch
@@ -1,0 +1,47 @@
+diff --git a/configure.ac b/configure.ac
+index 2b20543..7b4acb5 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -160,21 +160,21 @@ else
+     AC_MSG_NOTICE([optimization disabled (default)])
+ fi
+ 
+-if test "x$enable_cxx0" != 'xno'
+-then
+-    AC_MSG_NOTICE([c++x0 dialect is enabled (default), compilation with "-DHAVE_CXX0 -std=c++0x "])
+-    CPPFLAGS="$CPPFLAGS -DHAVE_CXX0 -std=c++0x";
+-else
+-    AC_MSG_NOTICE([c++x0 dialect is disabled, compilation without "-std=c++0x" and with "-UHAVE_CXX0"])
+-    CPPFLAGS="$CPPFLAGS -UHAVE_CXX0";
+-fi
+-
+ if test "x$with_zlib" != 'xno'
+ then
+   CPPFLAGS="$CPPFLAGS -I${with_zlib}/include"
+   LDFLAGS="$LDFLAGS -L${with_zlib}/lib"
+ fi
+ 
++if test "x$enable_cxx0" != 'xno'
++then
++    AC_MSG_NOTICE([c++x0 dialect is enabled (default), compilation with "-DHAVE_CXX0 -std=c++0x "])
++    CXXFLAGS="$CXXFLAGS -DHAVE_CXX0 -std=c++0x";
++else
++    AC_MSG_NOTICE([c++x0 dialect is disabled, compilation without "-std=c++0x" and with "-UHAVE_CXX0"])
++    CXXFLAGS="$CXXFLAGS -UHAVE_CXX0";
++fi
++
+ LIBS="$LIBS -lz"
+ 
+ AC_CONFIG_FILES([
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 6169e64..e08adbc 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -1,6 +1,6 @@
+ lib_LTLIBRARIES = libirstlm.la
+ 
+-AM_CXXFLAGS = -static -isystem/usr/include -W -Wall -ffor-scope -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES $(BOOST_CPPFLAGS) -DMYCODESIZE=3
++AM_CXXFLAGS = -static -W -Wall -ffor-scope -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES $(BOOST_CPPFLAGS) -DMYCODESIZE=3
+ 
+ libirstlm_ladir = ${includedir}
+ 


### PR DESCRIPTION
On Mac OS X, when running the ./extras/install_irstlm.sh script in XCode 9 (works fine in XCode 8):

```
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I.. -isystem/usr/include -W -Wall -ffor-scope -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -DMYCODESIZE=3 -MT interplm.lo -MD -MP -MF .deps/interplm.Tpo -c interplm.cpp -o interplm.o
In file included from interplm.cpp:21:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/cmath:313:9: error: no member named 'signbit' in the global namespace
using ::signbit;
      ~~^
...
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
make[1]: *** [interplm.lo] Error 1
make: *** [install-recursive] Error 1
***() Error compiling IRSTLM. The error messages could help you 
***() in figuring what went wrong.
```

On Ubuntu 17.04 with GCC 6 (works fine in GCC 5):
```
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I.. -isystem/usr/include -W -Wall -ffor-scope -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -DMYCODESIZE=3 -MT dictionary.lo -MD -MP -MF .deps/dictionary.Tpo -c dictionary.cpp -o dictionary.o
In file included from /usr/include/c++/6/ext/string_conversions.h:41:0,
                 from /usr/include/c++/6/bits/basic_string.h:5417,
                 from /usr/include/c++/6/string:52,
                 from /usr/include/c++/6/bits/locale_classes.h:40,
                 from /usr/include/c++/6/bits/ios_base.h:41,
                 from /usr/include/c++/6/ios:42,
                 from /usr/include/c++/6/ostream:38,
                 from /usr/include/c++/6/iostream:39,
                 from mfstream.h:26,
                 from dictionary.cpp:23:
/usr/include/c++/6/cstdlib:75:25: fatal error: stdlib.h: No such file or directory
 #include_next <stdlib.h>
```

Both are resolved through https://github.com/kaldi-asr/kaldi/issues/1588 and https://github.com/kaldi-asr/kaldi/pull/1713, whose files this PR imports.

(In general, we should be tracking the (largely-unmaintained) IRSTLM project on GitHub anyways, as opposed to SourceForge subversion).