### PR TITLE
Fix compilation on new macOS and new clang

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -654,8 +654,10 @@ if [ "`uname`" == "Darwin"  ]; then
   fi
   # posix_memalign and gcc -rdynamic options not present on OS X 10.5.*
   osx_ver=`sw_vers | grep ProductVersion | awk '{print $2}' | awk '{split($0,a,"\."); print a[1] "." a[2]; }'`
-  echo "Configuring for OS X version $osx_ver ..."
-  if [ "$osx_ver" == "10.5" ]; then
+  echo "Configuring for macOS version $osx_ver ..."
+  if [ "$osx_ver" == "10.0" ] || [ "$osx_ver" == "10.1" ] || [ "$osx_ver" == "10.2" ] || [ "$osx_ver" == "10.3" ] || [ "$osx_ver" == "10.4" ]; then
+    failure "macOS version must be at least 10.5"
+  elif [ "$osx_ver" == "10.5" ]; then
     check_exists makefiles/darwin_10_5.mk
     cat makefiles/darwin_10_5.mk >> config.mk
   elif [ "$osx_ver" == "10.6" ]; then
@@ -673,11 +675,11 @@ if [ "`uname`" == "Darwin"  ]; then
   elif [ "$osx_ver" == "10.10" ]; then
     check_exists makefiles/darwin_10_10.mk
     cat makefiles/darwin_10_10.mk >> config.mk
-  elif [ "$osx_ver" == "10.11" ]; then
+  elif [[ "$osx_ver" == 10.* ]]; then
     check_exists makefiles/darwin_10_11.mk
     cat makefiles/darwin_10_11.mk >> config.mk
   else 
-    failure "OS X version '$osx_ver' not supported"
+    failure "macOS version '$osx_ver' not supported"
   fi
   echo "Configuration succeeded for platform Darwin."
   exit_success;

--- a/src/lat/push-lattice.cc
+++ b/src/lat/push-lattice.cc
@@ -94,7 +94,7 @@ template<class Weight, class IntType> class CompactLatticePusher {
     // if there is conflict, and if so, reduce the "shift".
     bool is_final = (final != CompactWeight::Zero());
     size_t num_arcs = clat_->NumArcs(state);
-    if (num_arcs + (is_final ? 1 : 0) > 1 && shift > 0) {
+    if (num_arcs + (is_final ? 1 : 0) > 1 && shift > (void *)0) {
       // There is potential for conflict between string values, because >1
       // [arc or final-prob].  Find the longest shift up to and including the
       // current shift, that gives no conflict.


### PR DESCRIPTION
First, the `src/configure` script does not accept recent versions of Mac OS X:
```
...
On Darwin: checking for Accelerate framework ...
Configuring for OS X version 10.12 ...
***configure failed: OS X version '10.12' not supported ***
```
I modify the script to permissively accept 10.11+ using the right `.mk`.

Then, the following cast cannot be done implicitly in recent `clang`:
```
...
49 warnings generated.
clang++ -msse -msse2 -Wall -I.. -pthread -DKALDI_DOUBLEPRECISION=0 -DHAVE_POSIX_MEMALIGN -Wno-sign-compare -Winit-self -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_CLAPACK -I/Users/julsal/eesen/tools/openfst/include -DHAVE_OPENFST_GE_10400 -std=c++0x -Wno-sign-compare -g  -Wno-mismatched-tags   -c -o push-lattice.o push-lattice.cc
push-lattice.cc:97:52: error: ordered comparison between pointer and zero ('int32 *' (aka 'int *') and 'int')
    if (num_arcs + (is_final ? 1 : 0) > 1 && shift > 0) {
                                             ~~~~~ ^ ~
```
so we make it explicit.