### PR TITLE
Fix gpucompute compilation in CUDA 9 and in GCC 6+

### DIFF
--- a/src/gpucompute/Makefile
+++ b/src/gpucompute/Makefile
@@ -27,7 +27,7 @@ all:  $(LIBFILE)
 ifeq ($(CUDA), true)
 
   #Default compute capability architectures we compile with
-  CUDA_ARCH=-gencode arch=compute_20,code=sm_20
+  CUDA_ARCH=
 
   #Get the CUDA Toolkit version (remove decimal point char)
   CUDA_VERSION=$(shell $(CUDATKDIR)/bin/nvcc -V | grep release | sed -e 's|.*release ||' -e 's|,.*||' -e 's|\.||')
@@ -70,6 +70,12 @@ ifeq ($(CUDA), true)
   ifneq ($(CUDA_VER_GT_6_5), true)
     CUDA_ARCH += -gencode arch=compute_13,code=sm_13 \
                  -gencode arch=compute_10,code=sm_10 
+  endif
+
+  #For toolkit older than 9.0, add the compute capability 2.0
+  CUDA_VER_GT_9_0 := $(shell [ $(CUDA_VERSION) -ge 90 ] && echo true)
+  ifneq ($(CUDA_VER_GT_9_0), true)
+    CUDA_ARCH += -gencode arch=compute_20,code=sm_20
   endif
 
 endif

--- a/src/gpucompute/ctc-utils.h
+++ b/src/gpucompute/ctc-utils.h
@@ -21,7 +21,6 @@
 #define EESEN_GPUCOMPUTE_CTC_UTILS_H_
 
 //#if HAVE_CUDA == 1
-#pragma GCC diagnostic warning "-fpermissive"
 
 /*
  * Some numeric limits and operations. These limits and operations
@@ -34,33 +33,19 @@ struct NumericLimits;
 template <>
 struct NumericLimits<float>
 {
-#ifdef __NVCC__
-  static const float log_zero_ = -1e30f;
-  static const float exp_limit_ = 88.722839f;
-  static const float log_inf_ = 1e30f;
-  static const float max_ = 3.4028235e+038f;
-#else
   static constexpr float log_zero_ = -1e30f;
   static constexpr float exp_limit_ = 88.722839f;
   static constexpr float log_inf_ = 1e30f;
   static constexpr float max_ = 3.4028235e+038f;
-#endif
 };
 
 template <>
 struct NumericLimits<double>
 {
-#ifdef __NVCC__
-  static const double log_zero_ = -1e100;
-  static const double exp_limit_ = 709.78271289338397;
-  static const double log_inf_ = 1e100;
-  static const double max_ = 1.7976931348623157e+308;
-#else
   static constexpr double log_zero_ = -1e100;
   static constexpr double exp_limit_ = 709.78271289338397;
   static constexpr double log_inf_ = 1e100;
   static constexpr double max_ = 1.7976931348623157e+308;
-#endif
 };
 
 #if HAVE_CUDA == 1

--- a/src/makefiles/linux_cuda.mk
+++ b/src/makefiles/linux_cuda.mk
@@ -1,6 +1,6 @@
 
 CUDA_INCLUDE= -I$(CUDATKDIR)/include
-CUDA_FLAGS = -g -Xcompiler -fPIC --verbose --machine 32 -DHAVE_CUDA
+CUDA_FLAGS = -g -std=c++11 -Xcompiler -fPIC --verbose --machine 32 -DHAVE_CUDA
 
 CXXFLAGS += -DHAVE_CUDA -I$(CUDATKDIR)/include 
 LDFLAGS += -L$(CUDATKDIR)/lib -Wl,-rpath=$(CUDATKDIR)/lib

--- a/src/makefiles/linux_x86_64_cuda.mk
+++ b/src/makefiles/linux_x86_64_cuda.mk
@@ -1,6 +1,6 @@
 
 CUDA_INCLUDE= -I$(CUDATKDIR)/include
-CUDA_FLAGS = -g -Xcompiler -fPIC --verbose --machine 64 -DHAVE_CUDA
+CUDA_FLAGS = -g -std=c++11 -Xcompiler -fPIC --verbose --machine 64 -DHAVE_CUDA
 
 CXXFLAGS += -DHAVE_CUDA -I$(CUDATKDIR)/include 
 UNAME := $(shell uname)


### PR DESCRIPTION
When compiling EESEN on CUDA 9, one gets the following error in `src/gpucompute/Makefile`:
```
nvcc fatal : Unsupported gpu architecture 'compute_20'
```
since Compute Capability 2.x was removed in CUDA 9; see https://github.com/kaldi-asr/kaldi/issues/1918. This PR backports Kaldi's solution (https://github.com/kaldi-asr/kaldi/pull/1919).

Then, once `nvcc` and GCC 6+ are invoked, failure to use `constexpr` in src/gpucompute/ctc-utils.h is no longer tolerated, giving errors:
```
...
ctc-utils.h:57:54: error: ‘constexpr’ needed for in-class initialization of static data member ‘const double NumericLimits<double>::max_’ of non-integral type [-fpermissive]_
   static const double max_ = 1.7976931348623157e+308;
                                                      ^
# --error 0x1 --
Makefile:86: recipe for target 'cuda-kernels.o' failed
make[1]: *** [cuda-kernels.o] Error 1
```
Unconditionally using `constexpr` fixes this, but breaks `nvcc` and GCC 5:
```
#$ cudafe --allow_managed --m64 --gnu_version=50400 -tused --no_remove_unneeded_entities  --gen_c_file_name "/tmp/tmpxft_00001f4d_00000000-4_cuda-kernels.compute_20.cudafe1.c" --stub_file_name "/tmp/tmpxft_00001f4d_00000000-4_cuda-kernels.compute_20.cudafe1.stub.c" --gen_device_file_name "/tmp/tmpxft_00001f4d_00000000-4_cuda-kernels.compute_20.cudafe1.gpu" --nv_arch "compute_20" --gen_module_id_file --module_id_file_name "/tmp/tmpxft_00001f4d_00000000-3_cuda-kernels.module_id" --include_file_name "tmpxft_00001f4d_00000000-2_cuda-kernels.fatbin.c" "/tmp/tmpxft_00001f4d_00000000-19_cuda-kernels.compute_20.cpp1.ii" 
ctc-utils.h(36): error: explicit type is missing ("int" assumed)

ctc-utils.h(36): error: expected a ";"

ctc-utils.h(37): error: explicit type is missing ("int" assumed)

ctc-utils.h(37): error: "constexpr" has already been declared in the current scope

...
70 errors detected in the compilation of "/tmp/tmpxft_00001f4d_00000000-19_cuda-kernels.compute_20.cpp1.ii".
# --error 0x2 --
Makefile:86: recipe for target 'cuda-kernels.o' failed
```
Hence, this PR also passes `-std=c++11` to NVCC so that it tells GCC 5 to recognize the `constexpr` keyword as well.

I have tested the resulting PR on (x86-64):
- Ubuntu 17.04 + CUDA 9 + GCC 6.3
- Ubuntu 16.04 + CUDA 8 + GCC 5.4
- macOS 10.12 + CUDA 9 + Apple LLVM 8.1 (in conjunction with https://github.com/srvk/eesen/pull/162)