### PR TITLE
[tf_clean] lrscheduler objects (pull request reissue)

### DIFF
--- a/tf/ctc-am/constants.py
+++ b/tf/ctc-am/constants.py
@@ -138,3 +138,16 @@ class LRSCHEDULER_NAME:
     HALVSIES = "halvsies"
     NEWBOB = "newbob"
     CONSTANTLR = "constantlr"
+
+class LOG_TAGS_NEWBOB:
+    PHASE_STOP_EPOCH = "LRScheduler.Newbob: reached last epoch, ending training"
+    PHASE_0 = "LRScheduler.Newbob: not updating learning rate for first"
+    PHASE_MIN_LR = "LRScheduler.Newbob: not updating learning rate, currently at minimum"
+    PHASE_1 = "LRScheduler.Newbob: learning rate remaining constant"
+    PHASE_1_END = "LRScheduler.Newbob: beginning ramping to learn rate"
+    PHASE_2 = "LRScheduler.Newbob: learning rate ramping to"
+    PHASE_2_END = "LRScheduler.Newbob: stopping training"
+
+
+
+    

--- a/tf/ctc-am/constants.py
+++ b/tf/ctc-am/constants.py
@@ -65,6 +65,8 @@ class CONF_TAGS:
     #training runtime arguments
     NEPOCH="nepoch"
     LR_RATE="lr_rate"
+    LR_SPEC="lr_spec"
+    LRSCHEDULER="lrscheduler"
     MIN_LR_RATE="min_lr_rate"
     HALF_PERIOD="half_period"
     HALF_RATE="half_rate"
@@ -132,3 +134,7 @@ class LOG_TAGS:
     VALIDATE = "Validate"
 
 
+class LRSCHEDULER_NAME:
+    HALVSIES = "halvsies"
+    NEWBOB = "newbob"
+    CONSTANTLR = "constantlr"

--- a/tf/ctc-am/lrscheduler/constantlr.py
+++ b/tf/ctc-am/lrscheduler/constantlr.py
@@ -8,6 +8,7 @@
 
 import constants
 from lrscheduler.lrscheduler import LRScheduler
+import re
 
 class Constantlr(LRScheduler):
     def __init__(self, config):
@@ -34,7 +35,7 @@ class Constantlr(LRScheduler):
                     print('  example options: lr_rate=0.05,nepoch=10')
                     sys.exit()
             except ValueError:
-                print("Halvsies lr_spec: invalid type for var %s" % var)
+                print("Constantlr lr_spec: invalid type for var %s" % var)
                 print('  lr_spec="%s"' % self.__config[constants.CONF_TAGS.LR_SPEC])
                 print('  example options: lr_rate=0.05,nepoch=10')
                 sys.exit()
@@ -42,7 +43,14 @@ class Constantlr(LRScheduler):
 
     # TO DO: handle restarts
     def initialize_training(self):
+        self.__set_status("LRScheduler.Constantlr: initialized")
         return self.__epoch, self.__lr_rate
+
+    def __set_status(self,string):
+        self.__status=string
+
+    def get_status(self):
+        return self.__status
 
     def update_lr_rate(self, cv_ters):
         self.__epoch = self.__epoch + 1
@@ -50,9 +58,19 @@ class Constantlr(LRScheduler):
         should_stop = False 
         restore = None
 
-        if (self.__epoch+1 >= self.__nepoch):
-            print("LRScheduler.Constantlr: reached last epoch, ending training")
+        if (self.__epoch >= self.__nepoch+1):
+            self.__set_status("LRScheduler.Constantlr: reached last epoch, ending training")
             should_stop=True
-            
+        else:
+            self.__set_status("LRScheduler.Constantlr: continuing training")
+        
         return self.__epoch, self.__lr_rate, should_stop, restore
+
+    def set_epoch(self, epoch):
+        self.__epoch = epoch
+
+    def resume_from_log(self):
+        # this is pretty simple - allow new lr to replace old, so only need the epoch set
+        alpha = int(re.match(".*epoch([-+]?\d+).ckpt", self.__config[constants.CONF_TAGS.CONTINUE_CKPT]).groups()[0])
+        self.__epoch = alpha + 1
 

--- a/tf/ctc-am/lrscheduler/constantlr.py
+++ b/tf/ctc-am/lrscheduler/constantlr.py
@@ -1,0 +1,58 @@
+#
+# Halvsies learning rate schedule (from default tf_train schedule)
+#
+# Author: Eric Fosler-Lussier
+
+# This implements a constant training schedule
+# 
+
+import constants
+from lrscheduler.lrscheduler import LRScheduler
+
+class Constantlr(LRScheduler):
+    def __init__(self, config):
+        LRScheduler.__init__(self,config)
+        self.__config = config
+        self.__lr_rate = self.__config[constants.CONF_TAGS.LR_RATE]
+        self.__epoch = 1
+        self.__nepoch = self.__config[constants.CONF_TAGS.NEPOCH]
+        if (self.__config[constants.CONF_TAGS.LR_SPEC] is not ""):
+            self.__parse_spec()
+        
+    # process spec string
+    def __parse_spec(self):
+        for spec in self.__config[constants.CONF_TAGS.LR_SPEC].split(","):
+            var, value = spec.split("=")
+            try:
+                if (var == "lr_rate"):
+                    self.__lr_rate=float(value)
+                elif (var == "nepoch"):
+                    self.__nepoch=int(value)
+                else:
+                    print("Unknown option %s in Constantlr lr_spec." % var)
+                    print('  lr_spec="%s"' % self.__config[constants.CONF_TAGS.LR_SPEC])
+                    print('  example options: lr_rate=0.05,nepoch=10')
+                    sys.exit()
+            except ValueError:
+                print("Halvsies lr_spec: invalid type for var %s" % var)
+                print('  lr_spec="%s"' % self.__config[constants.CONF_TAGS.LR_SPEC])
+                print('  example options: lr_rate=0.05,nepoch=10')
+                sys.exit()
+        
+
+    # TO DO: handle restarts
+    def initialize_training(self):
+        return self.__epoch, self.__lr_rate
+
+    def update_lr_rate(self, cv_ters):
+        self.__epoch = self.__epoch + 1
+
+        should_stop = False 
+        restore = None
+
+        if (self.__epoch+1 >= self.__nepoch):
+            print("LRScheduler.Constantlr: reached last epoch, ending training")
+            should_stop=True
+            
+        return self.__epoch, self.__lr_rate, should_stop, restore
+

--- a/tf/ctc-am/lrscheduler/halvsies.py
+++ b/tf/ctc-am/lrscheduler/halvsies.py
@@ -1,0 +1,121 @@
+#
+# Halvsies learning rate schedule (from default tf_train schedule)
+#
+# Author: Eric Fosler-Lussier
+
+# This implements a training schedule that depends on the average token error rate (TER) of the CV set
+# 
+#  - initial learning rate is given by LR_RATE in config
+#  - learning rate stays constant for the first HALF_AFTER epochs
+#  - until minimum learning rate is reached:
+import constants
+from lrscheduler.lrscheduler import LRScheduler
+
+class Halvsies(LRScheduler):
+    def __init__(self, config):
+        LRScheduler.__init__(self,config)
+        self.__config = config
+        self.__lr_rate = self.__config[constants.CONF_TAGS.LR_RATE]
+        self.__epoch = 1
+        self.__best_avg_ters = 1000000000000000000.0
+        self.__best_epoch = None
+        self.__nepoch = self.__config[constants.CONF_TAGS.NEPOCH]
+        self.__half_after = self.__config[constants.CONF_TAGS.HALF_AFTER]
+        self.__half_rate = self.__config[constants.CONF_TAGS.HALF_RATE]
+        self.__min_lr_rate = self.__config[constants.CONF_TAGS.MIN_LR_RATE]
+        if (self.__config[constants.CONF_TAGS.LR_SPEC] is not ""):
+            self.__parse_spec()
+        
+    # process spec string
+    def __parse_spec(self):
+        for spec in self.__config[constants.CONF_TAGS.LR_SPEC].split(","):
+            var, value = spec.split("=")
+            try:
+                if (var == "lr_rate"):
+                    self.__lr_rate=float(value)
+                elif (var == "nepoch"):
+                    self.__nepoch=int(value)
+                elif (var == "half_after"):
+                    self.__half_after=int(value)
+                elif (var == "min_lr_rate"):
+                    self.__min_lr_rate=float(value)
+                elif (var == "half_rate"):
+                    self.__half_rate=float(value)
+                else:
+                    print("Unknown option %s in Halvsies lr_spec." % var)
+                    print('  lr_spec="%s"' % self.__config[constants.CONF_TAGS.LR_SPEC])
+                    print('  example options: lr_rate=0.05,nepoch=30,half_after=8,min_lr_rate=0.0005,half_rate=0.5')
+                    sys.exit()
+            except ValueError:
+                print("Halvsies lr_spec: invalid type for var %s" % var)
+                print('  lr_spec="%s"' % self.__config[constants.CONF_TAGS.LR_SPEC])
+                print('  example options: lr_rate=0.05,nepoch=30,half_after=8,min_lr_rate=0.0005,half_rate=0.5')
+                sys.exit()
+                
+        
+
+    # TO DO: handle restarts
+    def initialize_training(self):
+        return self.__epoch, self.__lr_rate
+
+    def update_lr_rate(self, cv_ters):
+        # when there are multiple ters, compute average
+        avg_ters = self.__compute_avg_ters(cv_ters)
+
+        should_stop = False 
+        restore = None
+
+        # original learning rate scheduler runs for a fixed number of iterations
+        if (self.__epoch+1 >= self.__nepoch):
+            print("LRScheduler.Halvsies: reached last epoch, ending training")
+            should_stop=True
+
+        if (self.__epoch < self.__half_after):
+            if (not should_stop):
+                print("LRScheduler.Halvsies: not updating learning rate for first %s epochs" % str(self.__half_after))
+            if (self.__epoch + 1 <= self.__half_after):
+                self.__best_avg_ters = avg_ters
+                self.__best_epoch = self.__epoch
+            self.__epoch = self.__epoch+1
+            return self.__epoch, self.__lr_rate, should_stop, restore
+
+
+        elif (self.__lr_rate <= self.__min_lr_rate):
+            if (not should_stop):
+                print("LRScheduler.Halvsies: not updating learning rate, currently at minimum ", self.__min_lr_rate)
+
+        elif (self.__best_avg_ters > avg_ters):
+            if (not should_stop):
+                print("LRScheduler.Halvsies: not updating learning rate, TER improved %.1f%% from epoch %d" % (100.0*(self.__best_avg_ters-avg_ters), self.__best_epoch))
+
+        else:
+            self.__lr_rate = self.__lr_rate * self.__half_rate
+            if (self.__lr_rate < self.__min_lr_rate):
+                self.__lr_rate = self.__min_lr_rate
+
+            if (should_stop):
+                print("LRScheduler.Halvsies: TER worse by %.1f%% from %.1f%% in epoch %d, will restore" % (100.0*(avg_ters-self.__best_avg_ters), 100.0*self.__best_avg_ters, self.__best_epoch))
+            else:
+                print("LRScheduler.Halvsies: TER worse by %.1f%% from %.1f%% in epoch %d, updating learning rate to %.4g" % (100.0*(avg_ters-self.__best_avg_ters), 100.0*self.__best_avg_ters, self.__best_epoch, self.__lr_rate))
+            restore = self.__best_epoch
+
+        if(self.__best_avg_ters > avg_ters):
+            self.__best_avg_ters = avg_ters
+            self.__best_epoch = self.__epoch
+
+        self.__epoch=self.__epoch+1
+
+        return self.__epoch, self.__lr_rate, should_stop, restore
+
+
+    def __compute_avg_ters(self, ters):
+        nters=0
+        avg_ters = 0.0
+        for language_id, target_scheme in ters.items():
+            for target_id, ter in target_scheme.items():
+                if(ter > 0):
+                    avg_ters += ter
+                    nters+=1
+        avg_ters /= float(nters)
+
+        return avg_ters

--- a/tf/ctc-am/lrscheduler/lrscheduler.py
+++ b/tf/ctc-am/lrscheduler/lrscheduler.py
@@ -1,0 +1,29 @@
+#                                                                                                                                                                                                                                             # LRScheduler Base Class
+#                                                                                                                                                                                                                                             
+# Author: Eric Fosler-Lussier                                                                                                                                                                                                                 
+
+# Provides base definition for class, common auxiliary functions
+ 
+class LRScheduler():
+
+    def __init__(self, config):
+        pass
+
+    def initialize_training(self):
+        pass
+
+    def update_lr_rate(self, cv_ters):
+        pass
+
+    def __compute_avg_ters(self, ters):
+        nters=0
+        avg_ters = 0.0
+        for language_id, target_scheme in ters.items():
+            for target_id, ter in target_scheme.items():
+                if(ter > 0):
+                    avg_ters += ter
+                    nters+=1
+        avg_ters /= float(nters)
+
+        return avg_ters
+

--- a/tf/ctc-am/lrscheduler/lrscheduler.py
+++ b/tf/ctc-am/lrscheduler/lrscheduler.py
@@ -15,6 +15,12 @@ class LRScheduler():
     def update_lr_rate(self, cv_ters):
         pass
 
+    def set_epoch(self, epoch):
+        pass
+
+    def resume_from_log(self):
+        pass
+
     def __compute_avg_ters(self, ters):
         nters=0
         avg_ters = 0.0

--- a/tf/ctc-am/lrscheduler/lrscheduler_factory.py
+++ b/tf/ctc-am/lrscheduler/lrscheduler_factory.py
@@ -1,0 +1,27 @@
+#
+# lrscheduler_factory.py: creates lrschedulers
+#
+# Author: Eric Fosler-Lussier
+
+from lrscheduler.halvsies import *
+from lrscheduler.newbob import *
+from lrscheduler.constantlr import *
+import constants
+
+
+#it returns an object lrscheduler that internaly will manage all the data
+#client will be agnostic for the internals
+def create_lrscheduler(config):
+
+    if config[constants.CONF_TAGS.LRSCHEDULER] == constants.LRSCHEDULER_NAME.HALVSIES:
+        return Halvsies(config)
+    elif config[constants.CONF_TAGS.LRSCHEDULER] == constants.LRSCHEDULER_NAME.NEWBOB:
+        return Newbob(config)
+    elif config[constants.CONF_TAGS.LRSCHEDULER] == constants.LRSCHEDULER_NAME.CONSTANTLR:
+        return Constantlr(config)
+    else:
+        print("lrscheduler selected does not exist")
+        print(debug.get_debug_info())
+        print("exiting...\n")
+        sys.exit()
+

--- a/tf/ctc-am/lrscheduler/newbob.py
+++ b/tf/ctc-am/lrscheduler/newbob.py
@@ -1,0 +1,143 @@
+#
+# Halvsies learning rate schedule (from default tf_train schedule)
+#
+# Author: Eric Fosler-Lussier
+
+# This implements a training schedule that depends on the average token error rate (TER) of the CV set
+# 
+#  - initial learning rate is given by LR_RATE in config
+#  - learning rate stays constant for the first HALF_AFTER epochs
+#  - learn rate remains constant until no improvement (or improvement less than threshold)
+#  - learn rate halves until no improvement (or improvement less than threshold)
+
+import constants
+from lrscheduler.lrscheduler import LRScheduler
+
+class Newbob(LRScheduler):
+    def __init__(self, config):
+        LRScheduler.__init__(self,config)
+        self.__config = config
+        self.__lr_rate = self.__config[constants.CONF_TAGS.LR_RATE]
+        self.__nepoch = self.__config[constants.CONF_TAGS.NEPOCH]
+        self.__half_after = self.__config[constants.CONF_TAGS.HALF_AFTER]
+        self.__phase = 0  # 0: burn in (constant), 1: constant until threshold, 2: ramping
+        self.__epoch = 1
+        self.__best_avg_ters = 1000000000000000000.0
+        self.__best_epoch = None
+        self.__ramp_threshold = 0.0
+        self.__stop_threshold = 0.0
+        self.__min_lr_rate = self.__config[constants.CONF_TAGS.MIN_LR_RATE]
+        self.__half_rate = self.__config[constants.CONF_TAGS.HALF_RATE]
+        if (self.__config[constants.CONF_TAGS.LR_SPEC] is not ""):
+            self.__parse_spec()
+        
+    # process spec string
+    def __parse_spec(self):
+        for spec in self.__config[constants.CONF_TAGS.LR_SPEC].split(","):
+            var, value = spec.split("=")
+            try:
+                if (var == "lr_rate"):
+                    self.__lr_rate=float(value)
+                elif (var == "nepoch"):
+                    self.__nepoch=int(value)
+                elif (var == "half_after"):
+                    self.__half_after=int(value)
+                elif (var == "ramp_threshold"):
+                    self.__ramp_threshold=float(value)
+                elif (var == "stop_threshold"):
+                    self.__stop_threshold=float(value)
+                elif (var == "min_lr_rate"):
+                    self.__min_lr_rate=float(value)
+                elif (var == "half_rate"):
+                    self.__half_rate=float(value)
+                else:
+                    print("Unknown option %s in Newbob lr_spec." % var)
+                    print('  lr_spec="%s"' % self.__config[constants.CONF_TAGS.LR_SPEC])
+                    print('  example options: lr_rate=0.05,nepoch=30,half_after=8,ramp_threshold=0.0,stop_threshold=0.0,min_lr_rate=0.0005,half_rate=0.5')
+                    sys.exit()
+            except ValueError:
+                print("Newbob lr_spec: invalid type for var %s" % var)
+                print('  lr_spec="%s"' % self.__config[constants.CONF_TAGS.LR_SPEC])
+                print('  example options: lr_rate=0.05,nepoch=30,half_after=8,ramp_threshold=0.0,stop_threshold=0.0,min_lr_rate=0.0005,half_rate=0.5')
+                sys.exit()
+                
+
+    # TO DO: handle restarts
+    def initialize_training(self):
+        return self.__epoch, self.__lr_rate
+
+    def update_lr_rate(self, cv_ters):
+        # when there are multiple ters, compute average
+        avg_ters = self.__compute_avg_ters(cv_ters)
+
+        should_stop = False 
+        restore = None
+
+        # original learning rate scheduler runs for a fixed number of iterations
+        if (self.__epoch+1 >= self.__nepoch):
+            print("LRScheduler.Newbob: reached last epoch, ending training")
+            should_stop=True
+
+        if (self.__epoch < self.__half_after):
+            if (not should_stop):
+                print("LRScheduler.Newbob: not updating learning rate for first %s epochs" % str(self.__half_after))
+            if (self.__epoch + 1 <= self.__half_after):
+                self.__best_avg_ters = avg_ters
+                self.__best_epoch = self.__epoch
+                self.__phase = 1  # start constant
+            self.__epoch = self.__epoch+1
+            return self.__epoch, self.__lr_rate, should_stop, restore
+
+
+        elif (self.__lr_rate <= self.__min_lr_rate):
+            if (not should_stop):
+                print("LRScheduler.Newbob: not updating learning rate, currently at minimum ", self.__min_lr_rate)
+
+        elif (self.__phase == 1):
+            if (self.__best_avg_ters - avg_ters >= self.__ramp_threshold):
+                if (not should_stop):
+                    print("LRScheduler.Newbob: learning rate remaining constant %.4g, TER improved %.1f%% from epoch %d" % (self.__lr_rate, 100.0*(self.__best_avg_ters-avg_ters), self.__best_epoch))
+            else:
+                if (not should_stop):
+                    self.__lr_rate = self.__lr_rate * self.__half_rate
+                    if (self.__lr_rate < self.__min_lr_rate):
+                        self.__lr_rate = self.__min_lr_rate
+                    self.__phase = 2
+                    print("LRScheduler.Newbob: beginning ramping to learn rate %.4g, TER difference %.1f%% under threshold %.1f%% from epoch %d" % (self.__lr_rate, 100.0*(self.__best_avg_ters-avg_ters), self.__ramp_threshold, self.__best_epoch))
+                    if (self.__best_avg_ters <= avg_ters):
+                        restore = self.__best_epoch
+                    
+        else:  # phase == 2
+            if (self.__best_avg_ters - avg_ters >= self.__stop_threshold):
+                self.__lr_rate = self.__lr_rate * self.__half_rate
+                if (self.__lr_rate < self.__min_lr_rate):
+                    self.__lr_rate = self.__min_lr_rate
+                if (not should_stop):
+                    print("LRScheduler.Newbob: learning rate ramping to %.4g, TER improved %.1f%% from epoch %d" % (self.__lr_rate, 100.0*(self.__best_avg_ters-avg_ters), self.__best_epoch))
+            else:
+                print("LRScheduler.Newbob: stopping training, TER difference %.1f%% under threshold %.1f%% from epoch %d" % (100.0*(self.__best_avg_ters-avg_ters), self.__ramp_threshold, self.__best_epoch))
+                should_stop = True
+                if (self.__best_avg_ters <= avg_ters):
+                    restore = self.__best_epoch
+
+
+        if(self.__best_avg_ters > avg_ters):
+            self.__best_avg_ters = avg_ters
+            self.__best_epoch = self.__epoch
+
+        self.__epoch=self.__epoch+1
+
+        return self.__epoch, self.__lr_rate, should_stop, restore
+
+
+    def __compute_avg_ters(self, ters):
+        nters=0
+        avg_ters = 0.0
+        for language_id, target_scheme in ters.items():
+            for target_id, ter in target_scheme.items():
+                if(ter > 0):
+                    avg_ters += ter
+                    nters+=1
+        avg_ters /= float(nters)
+
+        return avg_ters

--- a/tf/ctc-am/tf/tf_train.py
+++ b/tf/ctc-am/tf/tf_train.py
@@ -58,7 +58,7 @@ class Train():
 
             self.__lrscheduler=create_lrscheduler(self.__config)
 
-            # restore a training
+            # restore a training - note this will now update lrscheduler as well
             saver, alpha, best_avg_ters = self.__restore_weights()
 
             #initialize counters
@@ -67,15 +67,16 @@ class Train():
             #lr_rate = self.__config[constants.CONF_TAGS.LR_RATE]
             epoch, lr_rate = self.__lrscheduler.initialize_training()
 
-            if(alpha > 1):
-                if(self.__config[constants.CONF_TAGS.FORCE_LR_EPOCH_CKPT]):
-                    lr_rate = self.__config[constants.CONF_TAGS.LR_RATE]
-                    alpha=1
-                    self.__ter_buffer = [float('inf'), float('inf')]
-                    best_epoch=1
-                else:
-                    lr_rate = self.__config[constants.CONF_TAGS.LR_RATE]
-                    #lr_rate = self.__compute_new_lr_rate(alpha)
+            # This is now handled by the lrscheduler
+            #if(alpha > 1):
+            #    if(self.__config[constants.CONF_TAGS.FORCE_LR_EPOCH_CKPT]):
+            #        lr_rate = self.__config[constants.CONF_TAGS.LR_RATE]
+            #        alpha=1
+            #        self.__ter_buffer = [float('inf'), float('inf')]
+            #        best_epoch=1
+            #    else:
+            #        lr_rate = self.__config[constants.CONF_TAGS.LR_RATE]
+            #        #lr_rate = self.__compute_new_lr_rate(alpha)
 
             #for epoch in range(alpha, self.__config[constants.CONF_TAGS.NEPOCH]):
             while True:
@@ -95,12 +96,15 @@ class Train():
                 #evaluate on validation...
                 cv_cost, cv_ters, ncv = self.__eval_epoch(epoch, cv_x, cv_y, cv_sat)
 
-                self.__generate_logs(cv_ters, cv_cost, ncv, train_ters, train_cost, ntrain, epoch, lr_rate, tic)
-
                 #update lr_rate if needed
-                #lr_rate, best_avg_ters, best_epoch = self.__update_lr_rate(epoch, cv_ters, best_avg_ters, best_epoch, saver, lr_rate)
-                epoch, lr_rate, should_stop, restore = self.__lrscheduler.update_lr_rate(cv_ters)
+                new_epoch, new_lr_rate, should_stop, restore = self.__lrscheduler.update_lr_rate(cv_ters)
 
+                #generate logs after lrscheduler update so that the log can put out lrscheduler info
+                self.__generate_logs(cv_ters, cv_cost, ncv, train_ters, train_cost, ntrain, epoch, lr_rate, tic)
+                
+                epoch = new_epoch
+                lr_rate = new_lr_rate
+ 
                 # check restoring before stopping in case last model was suboptimal
                 if (restore is not None):
                     self.__restore_epoch(saver,restore)
@@ -620,6 +624,7 @@ class Train():
 
                 alpha += 1
 
+                self.__lrscheduler.set_epoch(alpha)
             else:
 
                 vars_to_load=[]
@@ -641,36 +646,39 @@ class Train():
                 saver = tf.train.Saver(max_to_keep=self.__config[constants.CONF_TAGS.NEPOCH], var_list=vars_to_load)
                 saver.restore(self.__sess, self.__config[constants.CONF_TAGS.CONTINUE_CKPT])
 
-                alpha = int(re.match(".*epoch([-+]?\d+).ckpt", self.__config[constants.CONF_TAGS.CONTINUE_CKPT]).groups()[0])
+                if True:
+                    self.__lrscheduler.resume_from_log()
+                else:
+                    alpha = int(re.match(".*epoch([-+]?\d+).ckpt", self.__config[constants.CONF_TAGS.CONTINUE_CKPT]).groups()[0])
 
-                num_val = 0
-                acum_val = 0
+                    num_val = 0
+                    acum_val = 0
 
-                with open(self.__config[constants.CONF_TAGS.CONTINUE_CKPT].replace(".ckpt",".log")) as input_file:
-                    for line in input_file:
-                        if (constants.LOG_TAGS.VALIDATE in line):
-                            acum_val += float(line.split()[4].replace("%,",""))
-                            num_val += 1
-
-                    self.__ter_buffer[len(self.__ter_buffer) - 1]= acum_val / num_val
-
-                    best_avg_ters=acum_val / num_val
-
-                if(alpha > 1):
-
-                    new_log=self.__config[constants.CONF_TAGS.CONTINUE_CKPT][:-7]+"%02d" % (alpha-1,)+".log"
-
-                    with open(new_log) as input_file:
+                    with open(self.__config[constants.CONF_TAGS.CONTINUE_CKPT].replace(".ckpt",".log")) as input_file:
                         for line in input_file:
                             if (constants.LOG_TAGS.VALIDATE in line):
                                 acum_val += float(line.split()[4].replace("%,",""))
                                 num_val += 1
 
-                    self.__ter_buffer[0]= acum_val / num_val
+                        self.__ter_buffer[len(self.__ter_buffer) - 1]= acum_val / num_val
+
+                        best_avg_ters=acum_val / num_val
+
+                        if(alpha > 1):
+
+                            new_log=self.__config[constants.CONF_TAGS.CONTINUE_CKPT][:-7]+"%02d" % (alpha-1,)+".log"
+
+                            with open(new_log) as input_file:
+                                for line in input_file:
+                                    if (constants.LOG_TAGS.VALIDATE in line):
+                                        acum_val += float(line.split()[4].replace("%,",""))
+                                        num_val += 1
+
+                            self.__ter_buffer[0]= acum_val / num_val
 
                 alpha += 1
 
-            print(80 * "-")
+        print(80 * "-")
 
         #we want to store everything
         saver = tf.train.Saver(max_to_keep=self.__config[constants.CONF_TAGS.NEPOCH])
@@ -698,6 +706,10 @@ class Train():
                     print("\t\t"+constants.LOG_TAGS.VALIDATE+" cost: %.1f, ter: %.1f%%, #example: %d" % (cv_cost[language_id][target_id], 100.0*cv_ter, ncv[language_id]))
                     fp.write("\t\tTrain    cost: %.1f, ter: %.1f%%, #example: %d\n" % (train_cost[language_id][target_id], 100.0*train_ters[language_id][target_id], ntrain[language_id]))
                     fp.write("\t\t"+constants.LOG_TAGS.VALIDATE+" cost: %.1f, ter: %.1f%%, #example: %d\n" % (cv_cost[language_id][target_id], 100.0*cv_ter, ncv[language_id]))
+                    fp.write(self.__lrscheduler.get_status())
+        # get status from LRScheduler
+        self.__info(self.__lrscheduler.get_status())
+
 
     def __print_counts_debug(self, epoch, batch_counter, total_number_batches, batch_cost, batch_size, batch_ters, data_queue):
 

--- a/tf/ctc-am/train.py
+++ b/tf/ctc-am/train.py
@@ -73,6 +73,8 @@ def main_parser():
 
     #training runtime arguments
     parser.add_argument('--nepoch', default = 30, type=int, help='#epoch')
+    parser.add_argument('--lrscheduler', default="halvsies", help = "lrscheduler: halvsies, newbob, constantlr") 
+    parser.add_argument('--lr_spec', default = "", help='option specifier string to lrscheduler, overrides other command line options')
     parser.add_argument('--lr_rate', default = 0.03, type=float, help='learning rate')
     parser.add_argument('--min_lr_rate', default = 0.0005, type=float, help='minimal learning rate')
     parser.add_argument('--half_period', default = 4, type=int, help='half period in epoch of learning rate')
@@ -188,6 +190,8 @@ def create_global_config(args):
 
         #training runtime arguments
         constants.CONF_TAGS.NEPOCH: args.nepoch,
+        constants.CONF_TAGS.LRSCHEDULER: args.lrscheduler,
+        constants.CONF_TAGS.LR_SPEC: args.lr_spec,
         constants.CONF_TAGS.LR_RATE: args.lr_rate,
         constants.CONF_TAGS.MIN_LR_RATE: args.min_lr_rate,
         constants.CONF_TAGS.HALF_PERIOD: args.half_period,
@@ -237,6 +241,9 @@ def update_conf_import(config, args):
 
     if(config[constants.CONF_TAGS.LR_RATE] != args.lr_rate):
         config[constants.CONF_TAGS.LR_RATE] = args.lr_rate
+
+    if(args.lrscheduler):
+        config[constants.CONF_TAGS.LRSCHEDULER] = args.lrscheduler
 
     if(config[constants.CONF_TAGS.MIN_LR_RATE] != args.min_lr_rate):
         config[constants.CONF_TAGS.MIN_LR_RATE] = args.min_lr_rate


### PR DESCRIPTION
This pull request separates out the logic for learning rate schedulers, and implements a modified "newbob" and constant rate scheduler.  The original scheduler in tf_train.py is now called "halvsies" and is the default.  

New command line options are ```-lrscheduler [halvsies,newbob,constantlr]``` and ```-lr_spec [string]```.  The lr_spec is a human readable set of options, separated by commas, and depends on the scheduler.

```
halvsies:lr_rate=0.05,nepoch=30,half_after=8,min_lr_rate=0.0005,half_rate=0.5
newbob:lr_rate=0.05,nepoch=30,half_after=8,ramp_threshold=0.0,stop_threshold=0.0,min_lr_rate=0.0005,half_rate=0.5
constantlr:lr_rate=0.05,nepoch=10
```

Note that some of these duplicate current command line options.  Specifying the lr_spec will override command line options.

```newbob``` is modified from the original algorithm to allow for a fixed burn in period (controlled by ```half_after```) variable thresholds (original algorithm sets these to 0.5) and specifying the halving rate (default is ```new_lr = lr * 0.5``` but the 0.5 can be adjusted by ```half_rate```)

Restarts: works as previously for ```halvsies```, and as you would expect for ```constantlr```.  For ```newbob``` the algorithm tries to guess which phase (burn in, constant, or ramping) the algorithm is in and then start from that point.  NB: it will respect ```lr_rate``` on the command line so if in ramping mode you need to make sure to set ```lr_rate``` correctly.